### PR TITLE
Escape input values in xml

### DIFF
--- a/src/openpersonen/api/models.py
+++ b/src/openpersonen/api/models.py
@@ -75,11 +75,6 @@ class StufBGClient(SingletonModel):
 
         request_data = loader.render_to_string(request_file, request_context)
 
-        try:
-            etree.fromstring(request_data, etree.XMLParser(dtd_validation=True))
-        except etree.XMLSyntaxError:
-            raise ValidationError('XML syntax incorrect,  likely received improper request_context')
-
         response = requests.post(
             self.url,
             data=request_data,

--- a/src/openpersonen/api/models.py
+++ b/src/openpersonen/api/models.py
@@ -2,14 +2,12 @@ import base64
 import uuid
 from datetime import timedelta
 
-from django.core.exceptions import ValidationError
 from django.db import models
 from django.template import loader
 from django.utils import dateformat, timezone
 from django.utils.translation import ugettext_lazy as _
 
 import requests
-from lxml import etree
 from solo.models import SingletonModel
 
 
@@ -73,11 +71,9 @@ class StufBGClient(SingletonModel):
         if additional_context:
             request_context.update(additional_context)
 
-        request_data = loader.render_to_string(request_file, request_context)
-
         response = requests.post(
             self.url,
-            data=request_data,
+            data=loader.render_to_string(request_file, request_context),
             headers=self._get_headers(),
         )
 

--- a/src/openpersonen/api/request_templates/RequestIngeschrevenPersoon.xml
+++ b/src/openpersonen/api/request_templates/RequestIngeschrevenPersoon.xml
@@ -56,65 +56,65 @@
                      StUF:sleutelGegevensbeheer="?" StUF:sleutelSynchronisatie="?" StUF:scope="?">
               {% if bsn %}
                   <!--Optional:-->
-                  <ns:inp.bsn StUF:exact="true">{{ bsn }}</ns:inp.bsn>
+                  <ns:inp.bsn StUF:exact="true">{{ bsn|escape }}</ns:inp.bsn>
               {% endif %}
               {% if geboorte__datum %}
                   <!--Optional:-->
                   <ns:geboortedatum StUF:exact="true" StUF:indOnvolledigeDatum="V">
-                      {{ geboorte__datum }}
+                      {{ geboorte__datum|escape }}
                   </ns:geboortedatum>
               {% endif %}
               {% if geboorte__plaats %}
                   <!--Optional:-->
-                  <ns:inp.geboorteplaats StUF:exact="true">{{ geboorte__plaats }}</ns:inp.geboorteplaats>
+                  <ns:inp.geboorteplaats StUF:exact="true">{{ geboorte__plaats|escape }}</ns:inp.geboorteplaats>
               {% endif %}
               {% if geslachtsaanduiding %}
                   <!--Optional:-->
-                  <ns:geslachtsaanduiding StUF:exact="true">{{ geslachtsaanduiding }}</ns:geslachtsaanduiding>
+                  <ns:geslachtsaanduiding StUF:exact="true">{{ geslachtsaanduiding|escape }}</ns:geslachtsaanduiding>
               {% endif %}
               {% if naam__geslachtsnaam %}
                   <!--Optional:-->
-                  <ns:geslachtsnaam StUF:exact="true">{{ naam__geslachtsnaam }}</ns:geslachtsnaam>
+                  <ns:geslachtsnaam StUF:exact="true">{{ naam__geslachtsnaam|escape }}</ns:geslachtsnaam>
               {% endif %}
               {% if naam__voornamen %}
                   <!--Optional:-->
-                  <ns:voornamen StUF:exact="true">{{ naam__voornamen }}</ns:voornamen>
+                  <ns:voornamen StUF:exact="true">{{ naam__voornamen|escape }}</ns:voornamen>
               {% endif %}
               {% if verblijfplaats__gemeentevaninschrijving %}
                   <!--Optional:-->
                   <ns:inp.gemeenteVanInschrijving StUF:exact="true">
-                      {{ verblijfplaats__gemeentevaninschrijving }}
+                      {{ verblijfplaats__gemeentevaninschrijving|escape }}
                   </ns:inp.gemeenteVanInschrijving>
               {% endif %}
               {% if naam__voorvoegsel %}
                   <!--Optional:-->
-                  <ns:voorvoegselGeslachtsnaam StUF:exact="true">{{ naam__voorvoegsel }}</ns:voorvoegselGeslachtsnaam>
+                  <ns:voorvoegselGeslachtsnaam StUF:exact="true">{{ naam__voorvoegsel|escape }}</ns:voorvoegselGeslachtsnaam>
               {% endif %}
               <!--Optional:-->
               <ns:verblijfsadres>
                   {% if verblijfplaats__huisletter %}
                       <!--Optional:-->
-                      <ns:aoa.huisletter StUF:exact="true">{{ verblijfplaats__huisletter }}</ns:aoa.huisletter>
+                      <ns:aoa.huisletter StUF:exact="true">{{ verblijfplaats__huisletter|escape }}</ns:aoa.huisletter>
                   {% endif %}
                   {% if verblijfplaats__huisnummer %}
                       <!--Optional:-->
-                      <ns:aoa.huisnummer StUF:exact="true">{{ verblijfplaats__huisnummer }}</ns:aoa.huisnummer>
+                      <ns:aoa.huisnummer StUF:exact="true">{{ verblijfplaats__huisnummer|escape }}</ns:aoa.huisnummer>
                   {% endif %}
                   {% if verblijfplaats__huisnummertoevoeging %}
                       <!--Optional:-->
                       <ns:aoa.huisnummertoevoeging StUF:exact="true">
-                          {{ verblijfplaats__huisnummertoevoeging }}
+                          {{ verblijfplaats__huisnummertoevoeging|escape }}
                       </ns:aoa.huisnummertoevoeging>
                   {% endif %}
                   {% if verblijfplaats__identificatiecodenummeraanduiding %}
                       <!--Optional:-->
                       <ns:aoa.identificatie StUF:exact="true">
-                          {{ verblijfplaats__identificatiecodenummeraanduiding }}
+                          {{ verblijfplaats__identificatiecodenummeraanduiding|escape }}
                       </ns:aoa.identificatie>
                   {% endif %}
                   {% if verblijfplaats__postcode %}
                       <!--Optional:-->
-                      <ns:aoa.postcode StUF:exact="true">{{ verblijfplaats__postcode }}</ns:aoa.postcode>
+                      <ns:aoa.postcode StUF:exact="true">{{ verblijfplaats__postcode|escape }}</ns:aoa.postcode>
                   {% endif %}
               </ns:verblijfsadres>
           </ns:gelijk>

--- a/src/openpersonen/api/request_templates/RequestIngeschrevenPersoon.xml
+++ b/src/openpersonen/api/request_templates/RequestIngeschrevenPersoon.xml
@@ -58,6 +58,10 @@
                   <!--Optional:-->
                   <ns:inp.bsn StUF:exact="true">{{ bsn|escape }}</ns:inp.bsn>
               {% endif %}
+                {% if burgerservicenummer %}
+                  <!--Optional:-->
+                  <ns:inp.bsn StUF:exact="true">{{ burgerservicenummer|escape }}</ns:inp.bsn>
+              {% endif %}
               {% if geboorte__datum %}
                   <!--Optional:-->
                   <ns:geboortedatum StUF:exact="true" StUF:indOnvolledigeDatum="V">

--- a/src/openpersonen/api/request_templates/RequestKind.xml
+++ b/src/openpersonen/api/request_templates/RequestKind.xml
@@ -53,7 +53,7 @@
          </ns:parameters>
          <!--Optional:-->
          <ns:gelijk StUF:entiteittype="NPS" StUF:sleutelVerzendend="?" StUF:sleutelOntvangend="?" StUF:sleutelGegevensbeheer="?" StUF:sleutelSynchronisatie="?" StUF:scope="?">
-            <ns:inp.bsn>{{ bsn }}</ns:inp.bsn>
+            <ns:inp.bsn>{{ bsn|escape }}</ns:inp.bsn>
          </ns:gelijk>
          <!--Optional:-->
          <ns:scope>

--- a/src/openpersonen/api/request_templates/RequestNationaliteitHistorie.xml
+++ b/src/openpersonen/api/request_templates/RequestNationaliteitHistorie.xml
@@ -42,7 +42,7 @@
          </ns:parameters>
          <!--Optional:-->
          <ns:gelijk StUF:entiteittype="NPS">
-            <ns:inp.bsn StUF:exact="true">{{ bsn }}</ns:inp.bsn>
+            <ns:inp.bsn StUF:exact="true">{{ bsn|escape }}</ns:inp.bsn>
          </ns:gelijk>
          <ns:scope>
             <ns:object StUF:entiteittype="NPS">

--- a/src/openpersonen/api/request_templates/RequestOuder.xml
+++ b/src/openpersonen/api/request_templates/RequestOuder.xml
@@ -53,7 +53,7 @@
          </ns:parameters>
          <!--Optional:-->
          <ns:gelijk StUF:entiteittype="NPS">
-            <ns:inp.bsn StUF:noValue="?" StUF:exact="true">{{ bsn }}</ns:inp.bsn>
+            <ns:inp.bsn StUF:noValue="?" StUF:exact="true">{{ bsn|escape }}</ns:inp.bsn>
          </ns:gelijk>
          <!--Optional:-->
          <ns:scope>

--- a/src/openpersonen/api/request_templates/RequestPartner.xml
+++ b/src/openpersonen/api/request_templates/RequestPartner.xml
@@ -53,7 +53,7 @@
          </ns:parameters>
          <!--Optional:-->
          <ns:gelijk StUF:entiteittype="NPS" StUF:sleutelVerzendend="?" StUF:sleutelOntvangend="?" StUF:sleutelGegevensbeheer="?" StUF:sleutelSynchronisatie="?" StUF:scope="?">
-            <ns:inp.bsn StUF:exact="true">{{ bsn }}</ns:inp.bsn>
+            <ns:inp.bsn StUF:exact="true">{{ bsn|escape }}</ns:inp.bsn>
          </ns:gelijk>
          <ns:scope>
             <ns:object StUF:entiteittype="NPS" StUF:sleutelVerzendend="?" StUF:sleutelOntvangend="?" StUF:sleutelGegevensbeheer="?" StUF:sleutelSynchronisatie="?" StUF:scope="?">

--- a/src/openpersonen/api/request_templates/RequestPartnerHistorie.xml
+++ b/src/openpersonen/api/request_templates/RequestPartnerHistorie.xml
@@ -42,7 +42,7 @@
          </ns:parameters>
          <!--Optional:-->
          <ns:gelijk StUF:entiteittype="NPS" StUF:sleutelVerzendend="?" StUF:sleutelOntvangend="?" StUF:sleutelGegevensbeheer="?" StUF:sleutelSynchronisatie="?" StUF:scope="?">
-            <ns:inp.bsn StUF:exact="true">{{ bsn }}</ns:inp.bsn>
+            <ns:inp.bsn StUF:exact="true">{{ bsn|escape }}</ns:inp.bsn>
          </ns:gelijk>
          <ns:scope>
             <ns:object StUF:entiteittype="NPS" StUF:sleutelVerzendend="?" StUF:sleutelOntvangend="?" StUF:sleutelGegevensbeheer="?" StUF:sleutelSynchronisatie="?" StUF:scope="?">

--- a/src/openpersonen/api/request_templates/RequestVerblijfPlaatsHistorie.xml
+++ b/src/openpersonen/api/request_templates/RequestVerblijfPlaatsHistorie.xml
@@ -42,7 +42,7 @@
          </ns:parameters>
          <!--Optional:-->
          <ns:gelijk StUF:entiteittype="NPS">
-            <ns:inp.bsn StUF:noValue="?" StUF:exact="true">{{ bsn }}</ns:inp.bsn>
+            <ns:inp.bsn StUF:noValue="?" StUF:exact="true">{{ bsn|escape }}</ns:inp.bsn>
          </ns:gelijk>
          <!--Optional:-->
          <ns:scope>

--- a/src/openpersonen/api/request_templates/RequestVerblijfsTitelHistorie.xml
+++ b/src/openpersonen/api/request_templates/RequestVerblijfsTitelHistorie.xml
@@ -42,7 +42,7 @@
          </ns:parameters>
          <!--Optional:-->
          <ns:gelijk StUF:entiteittype="NPS">
-            <ns:inp.bsn StUF:exact="true">{{ bsn }}</ns:inp.bsn>
+            <ns:inp.bsn StUF:exact="true">{{ bsn|escape }}</ns:inp.bsn>
          </ns:gelijk>
          <ns:scope>
             <ns:object StUF:entiteittype="NPS">


### PR DESCRIPTION
Partial solution for https://github.com/maykinmedia/open-personen/issues/43, addresses point 2

We should at least escape input values in XML since it's a simple way to help prevent issues from bad input data.

I didn't add any unit tests since I didn't think they'd be useful but I can add them if you think some should be added. :) 