### PR TITLE
Validate proper url paths

### DIFF
--- a/src/openpersonen/api/tests/test_data/nationaliteit_historie.py
+++ b/src/openpersonen/api/tests/test_data/nationaliteit_historie.py
@@ -38,5 +38,5 @@ NATIONALITEIT_HISTORIE_DATA = {
             }
         ]
     },
-    "url": "http://testserver/openpersonen/api/ingeschrevenpersonen/0/nationaliteithistorie",
+    "url": "http://testserver/openpersonen/api/ingeschrevenpersonen/123456789/nationaliteithistorie",
 }

--- a/src/openpersonen/api/tests/test_data/partner_historie.py
+++ b/src/openpersonen/api/tests/test_data/partner_historie.py
@@ -121,5 +121,5 @@ PARTNER_HISTORIE_DATA = {
             }
         ]
     },
-    "url": "http://testserver/openpersonen/api/ingeschrevenpersonen/0/partnerhistorie",
+    "url": "http://testserver/openpersonen/api/ingeschrevenpersonen/123456789/partnerhistorie",
 }

--- a/src/openpersonen/api/tests/test_data/verblijf_plaats_historie.py
+++ b/src/openpersonen/api/tests/test_data/verblijf_plaats_historie.py
@@ -98,5 +98,5 @@ VERBLIJF_PLAATS_HISTORIE_DATA = {
             }
         ]
     },
-    "url": "http://testserver/openpersonen/api/ingeschrevenpersonen/0/verblijfplaatshistorie",
+    "url": "http://testserver/openpersonen/api/ingeschrevenpersonen/123456789/verblijfplaatshistorie",
 }

--- a/src/openpersonen/api/tests/test_data/verblijfs_titel_historie.py
+++ b/src/openpersonen/api/tests/test_data/verblijfs_titel_historie.py
@@ -34,5 +34,5 @@ VERBLIJFS_TITEL_HISTORIE = {
             }
         ]
     },
-    "url": "http://testserver/openpersonen/api/ingeschrevenpersonen/0/verblijfstitelhistorie",
+    "url": "http://testserver/openpersonen/api/ingeschrevenpersonen/123456789/verblijfstitelhistorie",
 }

--- a/src/openpersonen/api/tests/views/test_kind.py
+++ b/src/openpersonen/api/tests/views/test_kind.py
@@ -1,6 +1,6 @@
 from django.template import loader
 from django.test import override_settings
-from django.urls import reverse
+from django.urls import NoReverseMatch, reverse
 
 import requests_mock
 from rest_framework.authtoken.models import Token
@@ -17,7 +17,7 @@ from openpersonen.api.views.generic_responses import RESPONSE_DATA_404
 class TestKind(APITestCase):
     def setUp(self):
         super().setUp()
-        self.persoon_bsn = 000000000
+        self.persoon_bsn = 123456789
         self.url = StufBGClient.get_solo().url
 
     def test_kind_without_token(self):
@@ -57,7 +57,7 @@ class TestKind(APITestCase):
                 "kinderen-detail",
                 kwargs={
                     "ingeschrevenpersonen_burgerservicenummer": self.persoon_bsn,
-                    "id": 1,
+                    "id": 987654321,
                 },
             ),
             HTTP_AUTHORIZATION=f"Token {token.key}",
@@ -67,12 +67,28 @@ class TestKind(APITestCase):
         self.assertTrue(post_mock.called)
         self.assertEqual(response.json(), KIND_RETRIEVE_DATA)
 
+    def test_detail_kind_with_bad_id(self):
+
+        user = User.objects.create(username="test")
+        token = Token.objects.create(user=user)
+        with self.assertRaises(NoReverseMatch):
+            self.client.get(
+                reverse(
+                    "kinderen-detail",
+                    kwargs={
+                        "ingeschrevenpersonen_burgerservicenummer": self.persoon_bsn,
+                        "id": "badid",
+                    },
+                ),
+                HTTP_AUTHORIZATION=f"Token {token.key}",
+            )
+
 
 @override_settings(USE_STUF_BG_DATABASE=True)
 class TestKindWithTestingModels(APITestCase):
     def setUp(self):
         super().setUp()
-        self.persoon_bsn = 000000000
+        self.persoon_bsn = 123456789
         self.partner_id = 111111111
         self.persoon = Persoon.objects.create(
             burgerservicenummer_persoon=self.persoon_bsn

--- a/src/openpersonen/api/tests/views/test_nationaliteit_historie.py
+++ b/src/openpersonen/api/tests/views/test_nationaliteit_historie.py
@@ -19,7 +19,7 @@ class TestNationaliteitHistorie(APITestCase):
         response = self.client.get(
             reverse(
                 "nationaliteithistorie-list",
-                kwargs={"ingeschrevenpersonen_burgerservicenummer": 000000000},
+                kwargs={"ingeschrevenpersonen_burgerservicenummer": 123456789},
             )
         )
         self.assertEqual(response.status_code, 401)
@@ -39,7 +39,7 @@ class TestNationaliteitHistorie(APITestCase):
         response = self.client.get(
             reverse(
                 "nationaliteithistorie-list",
-                kwargs={"ingeschrevenpersonen_burgerservicenummer": 000000000},
+                kwargs={"ingeschrevenpersonen_burgerservicenummer": 123456789},
             ),
             HTTP_AUTHORIZATION=f"Token {token.key}",
         )

--- a/src/openpersonen/api/tests/views/test_partner_historie.py
+++ b/src/openpersonen/api/tests/views/test_partner_historie.py
@@ -19,7 +19,7 @@ class TestPartnerHistorie(APITestCase):
         response = self.client.get(
             reverse(
                 "partnerhistorie-list",
-                kwargs={"ingeschrevenpersonen_burgerservicenummer": 000000000},
+                kwargs={"ingeschrevenpersonen_burgerservicenummer": 123456789},
             )
         )
         self.assertEqual(response.status_code, 401)
@@ -38,7 +38,7 @@ class TestPartnerHistorie(APITestCase):
         response = self.client.get(
             reverse(
                 "partnerhistorie-list",
-                kwargs={"ingeschrevenpersonen_burgerservicenummer": 000000000},
+                kwargs={"ingeschrevenpersonen_burgerservicenummer": 123456789},
             ),
             HTTP_AUTHORIZATION=f"Token {token.key}",
         )

--- a/src/openpersonen/api/tests/views/test_verblijf_plaats_historie.py
+++ b/src/openpersonen/api/tests/views/test_verblijf_plaats_historie.py
@@ -19,7 +19,7 @@ class TestVerblijfPlaatsHistorie(APITestCase):
         response = self.client.get(
             reverse(
                 "verblijfplaatshistorie-list",
-                kwargs={"ingeschrevenpersonen_burgerservicenummer": 000000000},
+                kwargs={"ingeschrevenpersonen_burgerservicenummer": 123456789},
             )
         )
         self.assertEqual(response.status_code, 401)
@@ -39,7 +39,7 @@ class TestVerblijfPlaatsHistorie(APITestCase):
         response = self.client.get(
             reverse(
                 "verblijfplaatshistorie-list",
-                kwargs={"ingeschrevenpersonen_burgerservicenummer": 000000000},
+                kwargs={"ingeschrevenpersonen_burgerservicenummer": 123456789},
             ),
             HTTP_AUTHORIZATION=f"Token {token.key}",
         )

--- a/src/openpersonen/api/tests/views/test_verblijf_titel_historie.py
+++ b/src/openpersonen/api/tests/views/test_verblijf_titel_historie.py
@@ -19,7 +19,7 @@ class TestVerblijfsTitelHistorie(APITestCase):
         response = self.client.get(
             reverse(
                 "verblijfstitelhistorie-list",
-                kwargs={"ingeschrevenpersonen_burgerservicenummer": 000000000},
+                kwargs={"ingeschrevenpersonen_burgerservicenummer": 123456789},
             )
         )
         self.assertEqual(response.status_code, 401)
@@ -39,7 +39,7 @@ class TestVerblijfsTitelHistorie(APITestCase):
         response = self.client.get(
             reverse(
                 "verblijfstitelhistorie-list",
-                kwargs={"ingeschrevenpersonen_burgerservicenummer": 000000000},
+                kwargs={"ingeschrevenpersonen_burgerservicenummer": 123456789},
             ),
             HTTP_AUTHORIZATION=f"Token {token.key}",
         )

--- a/src/openpersonen/api/views/base/nested_viewset.py
+++ b/src/openpersonen/api/views/base/nested_viewset.py
@@ -8,6 +8,10 @@ from openpersonen.api.views.generic_responses import RESPONSE_DATA_404
 
 
 class NestedViewSet(BaseViewSet):
+
+    lookup_field = "id"
+    lookup_value_regex = "[0-9]{9}"
+
     def list(self, request, *args, **kwargs):
         bsn = kwargs["ingeschrevenpersonen_burgerservicenummer"]
 

--- a/src/openpersonen/api/views/ingeschreven_persoon.py
+++ b/src/openpersonen/api/views/ingeschreven_persoon.py
@@ -15,6 +15,7 @@ from openpersonen.api.views.generic_responses import RESPONSE_DATA_404
 class IngeschrevenPersoonViewSet(BaseViewSet):
 
     lookup_field = "burgerservicenummer"
+    lookup_value_regex = "[0-9]{9}"
     serializer_class = IngeschrevenPersoonSerializer
     filter_class = IngeschrevenPersoonFilter
     filter_backends = [

--- a/src/openpersonen/api/views/kind.py
+++ b/src/openpersonen/api/views/kind.py
@@ -5,6 +5,5 @@ from openpersonen.api.views.base import NestedViewSet
 
 class KindViewSet(NestedViewSet):
 
-    lookup_field = "id"
     serializer_class = KindSerializer
     instance_class = Kind

--- a/src/openpersonen/api/views/ouder.py
+++ b/src/openpersonen/api/views/ouder.py
@@ -5,6 +5,5 @@ from openpersonen.api.views.base import NestedViewSet
 
 class OuderViewSet(NestedViewSet):
 
-    lookup_field = "id"
     serializer_class = OuderSerializer
     instance_class = Ouder

--- a/src/openpersonen/api/views/partner.py
+++ b/src/openpersonen/api/views/partner.py
@@ -5,6 +5,5 @@ from openpersonen.api.views.base import NestedViewSet
 
 class PartnerViewSet(NestedViewSet):
 
-    lookup_field = "id"
     serializer_class = PartnerSerializer
     instance_class = Partner


### PR DESCRIPTION
Partial solution for https://github.com/maykinmedia/open-personen/issues/43, addresses point 1.

This ensures the values passed in in the url are burger service nummers and not some other data.