### PR TITLE
Allow turning off permissions

### DIFF
--- a/src/openpersonen/api/tests/views/test_ingeschrevenpersoon.py
+++ b/src/openpersonen/api/tests/views/test_ingeschrevenpersoon.py
@@ -200,17 +200,11 @@ class TestIngeschrevenPersoonWithTestingModels(APITestCase):
         self.reisdocument = ReisdocumentFactory(persoon=self.persoon)
         self.verblijfplaats = VerblijfplaatsFactory(persoon=self.persoon)
         self.verblijfstitel = VerblijfstitelFactory(persoon=self.persoon)
-        self.token = TokenFactory.create()
-
-    def test_ingeschreven_persoon_without_token(self):
-        response = self.client.get(reverse("ingeschrevenpersonen-list"))
-        self.assertEqual(response.status_code, 401)
 
     def test_ingeschreven_persoon_with_token_and_proper_query_params(self):
 
         response = self.client.get(
-            reverse("ingeschrevenpersonen-list") + f"?burgerservicenummer={self.bsn}",
-            HTTP_AUTHORIZATION=f"Token {self.token.key}",
+            reverse("ingeschrevenpersonen-list") + f"?burgerservicenummer={self.bsn}"
         )
         self.assertEqual(response.status_code, 200)
         data = response.json()["_embedded"]["ingeschrevenpersonen"][0]
@@ -323,8 +317,7 @@ class TestIngeschrevenPersoonWithTestingModels(APITestCase):
     def test_ingeschreven_persoon_with_token_and_incorrect_proper_query_params(self):
 
         response = self.client.get(
-            reverse("ingeschrevenpersonen-list") + "?burgerservicenummer=1",
-            HTTP_AUTHORIZATION=f"Token {self.token.key}",
+            reverse("ingeschrevenpersonen-list") + "?burgerservicenummer=1"
         )
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.json()["_embedded"]["ingeschrevenpersonen"], [])
@@ -335,8 +328,7 @@ class TestIngeschrevenPersoonWithTestingModels(APITestCase):
             reverse(
                 "ingeschrevenpersonen-detail",
                 kwargs={"burgerservicenummer": self.bsn},
-            ),
-            HTTP_AUTHORIZATION=f"Token {self.token.key}",
+            )
         )
 
         self.assertEqual(response.status_code, 200)
@@ -453,8 +445,7 @@ class TestIngeschrevenPersoonWithTestingModels(APITestCase):
             reverse(
                 "ingeschrevenpersonen-detail",
                 kwargs={"burgerservicenummer": 111111111},
-            ),
-            HTTP_AUTHORIZATION=f"Token {self.token.key}",
+            )
         )
 
         self.assertEqual(response.status_code, 404)

--- a/src/openpersonen/api/tests/views/test_kind.py
+++ b/src/openpersonen/api/tests/views/test_kind.py
@@ -235,7 +235,6 @@ class TestKindWithTestingModels(APITestCase):
         self.kind = KindFactory(
             persoon=self.persoon, burgerservicenummer_kind=self.kind_bsn
         )
-        self.token = TokenFactory.create()
 
     def test_kind_without_token(self):
         response = self.client.get(
@@ -243,16 +242,6 @@ class TestKindWithTestingModels(APITestCase):
                 "kinderen-list",
                 kwargs={"ingeschrevenpersonen_burgerservicenummer": self.persoon_bsn},
             )
-        )
-        self.assertEqual(response.status_code, 401)
-
-    def test_kind_with_token(self):
-        response = self.client.get(
-            reverse(
-                "kinderen-list",
-                kwargs={"ingeschrevenpersonen_burgerservicenummer": self.persoon_bsn},
-            ),
-            HTTP_AUTHORIZATION=f"Token {self.token.key}",
         )
         self.assertEqual(response.status_code, 200)
 
@@ -262,8 +251,7 @@ class TestKindWithTestingModels(APITestCase):
             reverse(
                 "kinderen-list",
                 kwargs={"ingeschrevenpersonen_burgerservicenummer": self.persoon_bsn},
-            ),
-            HTTP_AUTHORIZATION=f"Token {self.token.key}",
+            )
         )
 
         self.assertEqual(response.status_code, 200)
@@ -304,8 +292,7 @@ class TestKindWithTestingModels(APITestCase):
                     "ingeschrevenpersonen_burgerservicenummer": self.persoon_bsn,
                     "id": self.kind_bsn,
                 },
-            ),
-            HTTP_AUTHORIZATION=f"Token {self.token.key}",
+            )
         )
 
         self.assertEqual(response.status_code, 200)
@@ -345,8 +332,7 @@ class TestKindWithTestingModels(APITestCase):
                     "ingeschrevenpersonen_burgerservicenummer": self.persoon_bsn,
                     "id": 222222222,
                 },
-            ),
-            HTTP_AUTHORIZATION=f"Token {self.token.key}",
+            )
         )
 
         self.assertEqual(response.status_code, 404)

--- a/src/openpersonen/api/tests/views/test_ouder.py
+++ b/src/openpersonen/api/tests/views/test_ouder.py
@@ -235,7 +235,6 @@ class TestOuderWithTestingModels(APITestCase):
         self.ouder = OuderFactory(
             persoon=self.persoon, burgerservicenummer_ouder=self.ouder_bsn
         )
-        self.token = TokenFactory.create()
 
     def test_ouder_without_token(self):
         response = self.client.get(
@@ -243,16 +242,6 @@ class TestOuderWithTestingModels(APITestCase):
                 "ouders-list",
                 kwargs={"ingeschrevenpersonen_burgerservicenummer": self.persoon_bsn},
             )
-        )
-        self.assertEqual(response.status_code, 401)
-
-    def test_ouder_with_token(self):
-        response = self.client.get(
-            reverse(
-                "ouders-list",
-                kwargs={"ingeschrevenpersonen_burgerservicenummer": self.persoon_bsn},
-            ),
-            HTTP_AUTHORIZATION=f"Token {self.token.key}",
         )
         self.assertEqual(response.status_code, 200)
 
@@ -262,8 +251,7 @@ class TestOuderWithTestingModels(APITestCase):
             reverse(
                 "ouders-list",
                 kwargs={"ingeschrevenpersonen_burgerservicenummer": self.persoon_bsn},
-            ),
-            HTTP_AUTHORIZATION=f"Token {self.token.key}",
+            )
         )
 
         self.assertEqual(response.status_code, 200)
@@ -304,8 +292,7 @@ class TestOuderWithTestingModels(APITestCase):
                     "ingeschrevenpersonen_burgerservicenummer": self.persoon_bsn,
                     "id": self.ouder_bsn,
                 },
-            ),
-            HTTP_AUTHORIZATION=f"Token {self.token.key}",
+            )
         )
 
         self.assertEqual(response.status_code, 200)
@@ -345,8 +332,7 @@ class TestOuderWithTestingModels(APITestCase):
                     "ingeschrevenpersonen_burgerservicenummer": self.persoon_bsn,
                     "id": 222222222,
                 },
-            ),
-            HTTP_AUTHORIZATION=f"Token {self.token.key}",
+            )
         )
 
         self.assertEqual(response.status_code, 404)

--- a/src/openpersonen/api/tests/views/test_partner.py
+++ b/src/openpersonen/api/tests/views/test_partner.py
@@ -236,7 +236,6 @@ class TestPartnerWithTestingModels(APITestCase):
             persoon=self.persoon,
             burgerservicenummer_echtgenoot_geregistreerd_partner=self.partner_bsn,
         )
-        self.token = TokenFactory.create()
 
     def test_partner_without_token(self):
         response = self.client.get(
@@ -244,16 +243,6 @@ class TestPartnerWithTestingModels(APITestCase):
                 "partners-list",
                 kwargs={"ingeschrevenpersonen_burgerservicenummer": self.persoon_bsn},
             )
-        )
-        self.assertEqual(response.status_code, 401)
-
-    def test_partner_with_token(self):
-        response = self.client.get(
-            reverse(
-                "partners-list",
-                kwargs={"ingeschrevenpersonen_burgerservicenummer": self.persoon_bsn},
-            ),
-            HTTP_AUTHORIZATION=f"Token {self.token.key}",
         )
         self.assertEqual(response.status_code, 200)
 
@@ -263,8 +252,7 @@ class TestPartnerWithTestingModels(APITestCase):
             reverse(
                 "partners-list",
                 kwargs={"ingeschrevenpersonen_burgerservicenummer": self.persoon_bsn},
-            ),
-            HTTP_AUTHORIZATION=f"Token {self.token.key}",
+            )
         )
 
         self.assertEqual(response.status_code, 200)
@@ -324,8 +312,7 @@ class TestPartnerWithTestingModels(APITestCase):
                     "ingeschrevenpersonen_burgerservicenummer": self.persoon_bsn,
                     "id": self.partner_bsn,
                 },
-            ),
-            HTTP_AUTHORIZATION=f"Token {self.token.key}",
+            )
         )
 
         self.assertEqual(response.status_code, 200)
@@ -384,8 +371,7 @@ class TestPartnerWithTestingModels(APITestCase):
                     "ingeschrevenpersonen_burgerservicenummer": self.persoon_bsn,
                     "id": 222222222,
                 },
-            ),
-            HTTP_AUTHORIZATION=f"Token {self.token.key}",
+            )
         )
 
         self.assertEqual(response.status_code, 404)

--- a/src/openpersonen/api/views/base/base_viewset.py
+++ b/src/openpersonen/api/views/base/base_viewset.py
@@ -1,5 +1,6 @@
-from rest_framework.permissions import IsAuthenticated
 from rest_framework.viewsets import ViewSet
+
+from openpersonen.api.views.permissions import IsAuthenticated
 
 
 class BaseViewSet(ViewSet):

--- a/src/openpersonen/api/views/permissions.py
+++ b/src/openpersonen/api/views/permissions.py
@@ -1,0 +1,14 @@
+from django.conf import settings
+
+from rest_framework.permissions import BasePermission
+
+
+class IsAuthenticated(BasePermission):
+    """
+    Allows access only to authenticated users.
+    """
+
+    def has_permission(self, request, view):
+        return settings.USE_STUF_BG_DATABASE or bool(
+            request.user and request.user.is_authenticated
+        )


### PR DESCRIPTION
Fixed #90 

Adds a custom permission so a user does not need to be authenticated or use a token if running in demo mode.