### PR TITLE
Turn off auth option

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,6 +15,7 @@ services:
       - DB_USER=${DB_USER:-openpersonen}
       - DB_PASSWORD=${DB_PASSWORD:-openpersonen}
       - USE_STUF_BG_DATABASE=${USE_STUF_BG_DATABASE:-False}
+      - USE_AUTHENTICATION=${USE_AUTHENTICATION:-True}
     #   Uncomment below and update path on left side to use test data from file system
     #     when importing csv test data
 #    volumes:

--- a/src/openpersonen/api/tests/views/test_permissions.py
+++ b/src/openpersonen/api/tests/views/test_permissions.py
@@ -1,0 +1,40 @@
+from django.test import override_settings
+from django.urls import reverse
+
+from rest_framework.test import APITestCase
+
+from openpersonen.api.tests.factory_models import TokenFactory
+
+
+class TestPermissions(APITestCase):
+    @override_settings(USE_STUF_BG_DATABASE=True, USE_AUTHENTICATION=True)
+    def test_use_authentication_and_use_database(self):
+        token = TokenFactory.create()
+        response = self.client.get(
+            reverse("ingeschrevenpersonen-list") + "?burgerservicenummer=123456789",
+            HTTP_AUTHORIZATION=f"Token {token.key}",
+        )
+        self.assertEqual(response.status_code, 200)
+
+    @override_settings(USE_STUF_BG_DATABASE=True, USE_AUTHENTICATION=False)
+    def test_not_use_authentication_and_use_database(self):
+        response = self.client.get(
+            reverse("ingeschrevenpersonen-list") + "?burgerservicenummer=123456789"
+        )
+        self.assertEqual(response.status_code, 200)
+
+    @override_settings(USE_STUF_BG_DATABASE=True, USE_AUTHENTICATION=True)
+    def test_use_authentication_and_not_use_database(self):
+        token = TokenFactory.create()
+        response = self.client.get(
+            reverse("ingeschrevenpersonen-list") + "?burgerservicenummer=123456789",
+            HTTP_AUTHORIZATION=f"Token {token.key}",
+        )
+        self.assertEqual(response.status_code, 200)
+
+    @override_settings(USE_STUF_BG_DATABASE=False)
+    def test_not_use_authentication_and_not_use_database(self):
+        response = self.client.get(
+            reverse("ingeschrevenpersonen-list") + "?burgerservicenummer=123456789"
+        )
+        self.assertEqual(response.status_code, 401)

--- a/src/openpersonen/api/tests/views/test_permissions.py
+++ b/src/openpersonen/api/tests/views/test_permissions.py
@@ -1,8 +1,12 @@
+from django.core.exceptions import ImproperlyConfigured
+from django.template import loader
 from django.test import override_settings
 from django.urls import reverse
 
+import requests_mock
 from rest_framework.test import APITestCase
 
+from openpersonen.api.models import StufBGClient
 from openpersonen.api.tests.factory_models import TokenFactory
 
 
@@ -23,18 +27,28 @@ class TestPermissions(APITestCase):
         )
         self.assertEqual(response.status_code, 200)
 
-    @override_settings(USE_STUF_BG_DATABASE=True, USE_AUTHENTICATION=True)
-    def test_use_authentication_and_not_use_database(self):
-        token = TokenFactory.create()
-        response = self.client.get(
-            reverse("ingeschrevenpersonen-list") + "?burgerservicenummer=123456789",
-            HTTP_AUTHORIZATION=f"Token {token.key}",
-        )
-        self.assertEqual(response.status_code, 200)
-
-    @override_settings(USE_STUF_BG_DATABASE=False)
-    def test_not_use_authentication_and_not_use_database(self):
-        response = self.client.get(
+    @override_settings(USE_STUF_BG_DATABASE=False, USE_AUTHENTICATION=True)
+    @requests_mock.Mocker()
+    def test_use_authentication_and_not_use_database(self, post_mock):
+        client_url = StufBGClient.get_solo().url
+        api_url = (
             reverse("ingeschrevenpersonen-list") + "?burgerservicenummer=123456789"
         )
-        self.assertEqual(response.status_code, 401)
+        post_mock.post(
+            client_url,
+            content=bytes(
+                loader.render_to_string("ResponseTwoIngeschrevenPersoon.xml"),
+                encoding="utf-8",
+            ),
+        )
+
+        token = TokenFactory.create()
+        response = self.client.get(api_url, HTTP_AUTHORIZATION=f"Token {token.key}")
+        self.assertEqual(response.status_code, 200)
+
+    @override_settings(USE_STUF_BG_DATABASE=False, USE_AUTHENTICATION=False)
+    def test_not_use_authentication_and_not_use_database(self):
+        with self.assertRaises(ImproperlyConfigured):
+            self.client.get(
+                reverse("ingeschrevenpersonen-list") + "?burgerservicenummer=123456789"
+            )

--- a/src/openpersonen/api/views/base/base_viewset.py
+++ b/src/openpersonen/api/views/base/base_viewset.py
@@ -1,5 +1,6 @@
-from rest_framework.permissions import IsAuthenticated
 from rest_framework.viewsets import ViewSet
+
+from openpersonen.api.views.permissions import IsAuthenticated
 
 
 class BaseViewSet(ViewSet):

--- a/src/openpersonen/api/views/permissions.py
+++ b/src/openpersonen/api/views/permissions.py
@@ -1,0 +1,15 @@
+from django.conf import settings
+
+from rest_framework.permissions import BasePermission
+
+
+class IsAuthenticated(BasePermission):
+    """
+    Allows access only to authenticated users.
+    """
+
+    def has_permission(self, request, view):
+        if settings.USE_AUTHENTICATION:
+            return bool(request.user and request.user.is_authenticated)
+        else:
+            return True

--- a/src/openpersonen/api/views/permissions.py
+++ b/src/openpersonen/api/views/permissions.py
@@ -1,4 +1,5 @@
 from django.conf import settings
+from django.core.exceptions import ImproperlyConfigured
 
 from rest_framework.permissions import IsAuthenticated as _IsAuthenticated
 
@@ -8,4 +9,8 @@ class IsAuthenticated(_IsAuthenticated):
         if settings.USE_AUTHENTICATION:
             return super().has_permission(request, view)
         else:
+            if not settings.USE_STUF_BG_DATABASE:
+                raise ImproperlyConfigured(
+                    "Must use authentication when not using local database"
+                )
             return True

--- a/src/openpersonen/api/views/permissions.py
+++ b/src/openpersonen/api/views/permissions.py
@@ -1,15 +1,12 @@
 from django.conf import settings
 
-from rest_framework.permissions import BasePermission
+from rest_framework.permissions import IsAuthenticated as _IsAuthenticated
 
 
-class IsAuthenticated(BasePermission):
-    """
-    Allows access only to authenticated users.
-    """
+class IsAuthenticated(_IsAuthenticated):
 
     def has_permission(self, request, view):
         if settings.USE_AUTHENTICATION:
-            return bool(request.user and request.user.is_authenticated)
+            return super().has_permission(request, view)
         else:
             return True

--- a/src/openpersonen/api/views/permissions.py
+++ b/src/openpersonen/api/views/permissions.py
@@ -4,7 +4,6 @@ from rest_framework.permissions import IsAuthenticated as _IsAuthenticated
 
 
 class IsAuthenticated(_IsAuthenticated):
-
     def has_permission(self, request, view):
         if settings.USE_AUTHENTICATION:
             return super().has_permission(request, view)

--- a/src/openpersonen/conf/base.py
+++ b/src/openpersonen/conf/base.py
@@ -1,6 +1,7 @@
 import os
 
 # Django-hijack (and Django-hijack-admin)
+from django.core.exceptions import ImproperlyConfigured
 from django.urls import reverse_lazy
 
 from sentry_sdk.integrations import DidNotEnable, django, redis
@@ -411,3 +412,10 @@ DAY_START = 6
 DAY_END = 8
 
 USE_STUF_BG_DATABASE = os.getenv("USE_STUF_BG_DATABASE") == "True"
+USE_AUTHENTICATION = not USE_STUF_BG_DATABASE
+
+if os.getenv("USE_AUTHENTICATION"):
+    USE_AUTHENTICATION = os.getenv("USE_AUTHENTICATION") == "True"
+
+if not USE_AUTHENTICATION and not USE_STUF_BG_DATABASE:
+    raise ImproperlyConfigured('Must use authentication when not using local database')

--- a/src/openpersonen/conf/base.py
+++ b/src/openpersonen/conf/base.py
@@ -418,4 +418,4 @@ if os.getenv("USE_AUTHENTICATION"):
     USE_AUTHENTICATION = os.getenv("USE_AUTHENTICATION") == "True"
 
 if not USE_AUTHENTICATION and not USE_STUF_BG_DATABASE:
-    raise ImproperlyConfigured('Must use authentication when not using local database')
+    raise ImproperlyConfigured("Must use authentication when not using local database")

--- a/src/openpersonen/conf/base.py
+++ b/src/openpersonen/conf/base.py
@@ -1,7 +1,6 @@
 import os
 
 # Django-hijack (and Django-hijack-admin)
-from django.core.exceptions import ImproperlyConfigured
 from django.urls import reverse_lazy
 
 from sentry_sdk.integrations import DidNotEnable, django, redis
@@ -416,6 +415,3 @@ USE_AUTHENTICATION = not USE_STUF_BG_DATABASE
 
 if os.getenv("USE_AUTHENTICATION"):
     USE_AUTHENTICATION = os.getenv("USE_AUTHENTICATION") == "True"
-
-if not USE_AUTHENTICATION and not USE_STUF_BG_DATABASE:
-    raise ImproperlyConfigured("Must use authentication when not using local database")


### PR DESCRIPTION
Fixed #90 

Add new option to turn off authentication when using database.  Defaults to authentication being on when not using database and being off when using database but can be configured.  Will raise exception if authentication is off and not using the database. 