### PR TITLE
Use demo data and no auth by default

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,12 +14,8 @@ services:
       - SECRET_KEY=${SECRET_KEY:-%9+dfjw+zd3@q)ehsx(pdwy-ueq0zt=90gb4+&qd^6ytpj@p7#}
       - DB_USER=${DB_USER:-openpersonen}
       - DB_PASSWORD=${DB_PASSWORD:-openpersonen}
-      - USE_STUF_BG_DATABASE=${USE_STUF_BG_DATABASE:-False}
-      - USE_AUTHENTICATION=${USE_AUTHENTICATION:-True}
-    #   Uncomment below and update path on left side to use test data from file system
-    #     when importing csv test data
-#    volumes:
-#      - /path/to/files:/app/src/openpersonen/api/management/commands/data
+      - USE_STUF_BG_DATABASE=${USE_STUF_BG_DATABASE:-True}
+      - USE_AUTHENTICATION=${USE_AUTHENTICATION:-False}
     ports:
       - 8000:8000
     depends_on:


### PR DESCRIPTION
When using Docker-Compose, we make the developer experience as easy as possible.