### PR TITLE
Fix bug between JSONHal library and APIRootView from vng-api-common

### DIFF
--- a/src/openpersonen/api/tests/views/test_api_root.py
+++ b/src/openpersonen/api/tests/views/test_api_root.py
@@ -1,0 +1,9 @@
+from rest_framework.test import APITestCase
+
+
+class TestAPIRootView(APITestCase):
+
+    def test_api_root(self):
+        response = self.client.get('/api', follow=True)
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(b'{"ingeschrevenpersonen":"http://testserver/api/ingeschrevenpersonen"}', response.content)

--- a/src/openpersonen/api/tests/views/test_api_root.py
+++ b/src/openpersonen/api/tests/views/test_api_root.py
@@ -2,8 +2,10 @@ from rest_framework.test import APITestCase
 
 
 class TestAPIRootView(APITestCase):
-
     def test_api_root(self):
-        response = self.client.get('/api', follow=True)
+        response = self.client.get("/api", follow=True)
         self.assertEqual(response.status_code, 200)
-        self.assertEqual(b'{"ingeschrevenpersonen":"http://testserver/api/ingeschrevenpersonen"}', response.content)
+        self.assertEqual(
+            b'{"ingeschrevenpersonen":"http://testserver/api/ingeschrevenpersonen"}',
+            response.content,
+        )

--- a/src/openpersonen/api/urls.py
+++ b/src/openpersonen/api/urls.py
@@ -9,6 +9,7 @@ from vng_api_common.schema import SchemaView as _SchemaView
 
 from openpersonen.api.schema import info
 from openpersonen.api.views import (
+    APIRootView,
     IngeschrevenPersoonViewSet,
     KindViewSet,
     NationaliteitHistorieViewSet,
@@ -20,6 +21,7 @@ from openpersonen.api.views import (
 )
 
 router = routers.DefaultRouter()
+router.APIRootView = APIRootView
 
 
 router.register(

--- a/src/openpersonen/api/views/__init__.py
+++ b/src/openpersonen/api/views/__init__.py
@@ -1,3 +1,4 @@
+from .api_root import APIRootView
 from .ingeschreven_persoon import IngeschrevenPersoonViewSet
 from .kind import KindViewSet
 from .nationaliteit_historie import NationaliteitHistorieViewSet

--- a/src/openpersonen/api/views/api_root.py
+++ b/src/openpersonen/api/views/api_root.py
@@ -1,0 +1,6 @@
+from vng_api_common.routers import APIRootView as _APIRootView
+
+
+class APIRootView(_APIRootView):
+    action = "list"
+    basename = "ingeschrevenpersonen"


### PR DESCRIPTION
Fixes #85 

Due to the json hal library expecting the APIRootView to have a basename and action https://github.com/maykinmedia/djangorestframework-hal/blob/master/djangorestframework_hal/renderers.py#L16-L22 this previously through an exception since these were not set on the APIRootView that came from vng-api-common.

To fix this conflict I inherited the APIRootView from vng-api-common and added these attributes. 