### PR TITLE
Add custom error responses

### DIFF
--- a/src/openpersonen/api/tests/views/test_errors.py
+++ b/src/openpersonen/api/tests/views/test_errors.py
@@ -8,7 +8,6 @@ from openpersonen.api.views.generic_responses import get_404_response
 
 @override_settings(DEBUG=False)
 class Test404Response(APITestCase):
-
     def setUp(self):
         super().setUp()
         self.token = TokenFactory.create()

--- a/src/openpersonen/api/tests/views/test_errors.py
+++ b/src/openpersonen/api/tests/views/test_errors.py
@@ -8,10 +8,15 @@ from openpersonen.api.views.generic_responses import get_404_response
 
 @override_settings(DEBUG=False)
 class Test404Response(APITestCase):
+
+    def setUp(self):
+        super().setUp()
+        self.token = TokenFactory.create()
+
     def test_default_404_response(self):
         response = self.client.get(
             "/non-existant-endpoint",
-            HTTP_AUTHORIZATION=f"Token {TokenFactory.create().key}",
+            HTTP_AUTHORIZATION=f"Token {self.token.key}",
         )
 
         self.assertEqual(response.status_code, 404)
@@ -20,7 +25,7 @@ class Test404Response(APITestCase):
     def test_custom_404_response(self):
         response = self.client.get(
             "/api/non-existant-endpoint",
-            HTTP_AUTHORIZATION=f"Token {TokenFactory.create().key}",
+            HTTP_AUTHORIZATION=f"Token {self.token.key}",
         )
 
         self.assertEqual(response.status_code, 404)

--- a/src/openpersonen/api/tests/views/test_errors.py
+++ b/src/openpersonen/api/tests/views/test_errors.py
@@ -3,6 +3,7 @@ from django.test import override_settings
 from rest_framework.test import APITestCase
 
 from openpersonen.api.tests.factory_models import TokenFactory
+from openpersonen.api.views.generic_responses import get_404_response
 
 
 @override_settings(DEBUG=False)
@@ -23,18 +24,7 @@ class Test404Response(APITestCase):
         )
 
         self.assertEqual(response.status_code, 404)
-        json_response = response.json()
         self.assertEqual(
-            json_response["type"],
-            "https://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#/10.4.5 404 Not Found",
+            response.json(),
+            get_404_response("http://testserver/api/non-existant-endpoint"),
         )
-        self.assertEqual(json_response["title"], "Opgevraagde resource bestaat niet.")
-        self.assertEqual(json_response["status"], 404)
-        self.assertEqual(
-            json_response["detail"],
-            "The server has not found anything matching the Request-URI.",
-        )
-        self.assertEqual(
-            json_response["instance"], "http://testserver/api/non-existant-endpoint"
-        )
-        self.assertEqual(json_response["code"], "notFound")

--- a/src/openpersonen/api/tests/views/test_errors.py
+++ b/src/openpersonen/api/tests/views/test_errors.py
@@ -1,0 +1,40 @@
+from django.test import override_settings
+
+from rest_framework.test import APITestCase
+
+from openpersonen.api.tests.factory_models import TokenFactory
+
+
+@override_settings(DEBUG=False)
+class Test404Response(APITestCase):
+    def test_default_404_response(self):
+        response = self.client.get(
+            "/non-existant-endpoint",
+            HTTP_AUTHORIZATION=f"Token {TokenFactory.create().key}",
+        )
+
+        self.assertEqual(response.status_code, 404)
+        self.assertIn("<h1>Not Found</h1>", str(response.content))
+
+    def test_custom_404_response(self):
+        response = self.client.get(
+            "/api/non-existant-endpoint",
+            HTTP_AUTHORIZATION=f"Token {TokenFactory.create().key}",
+        )
+
+        self.assertEqual(response.status_code, 404)
+        json_response = response.json()
+        self.assertEqual(
+            json_response["type"],
+            "https://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#/10.4.5 404 Not Found",
+        )
+        self.assertEqual(json_response["title"], "Opgevraagde resource bestaat niet.")
+        self.assertEqual(json_response["status"], 404)
+        self.assertEqual(
+            json_response["detail"],
+            "The server has not found anything matching the Request-URI.",
+        )
+        self.assertEqual(
+            json_response["instance"], "http://testserver/api/non-existant-endpoint"
+        )
+        self.assertEqual(json_response["code"], "notFound")

--- a/src/openpersonen/api/views/errors.py
+++ b/src/openpersonen/api/views/errors.py
@@ -1,0 +1,35 @@
+from django.http import JsonResponse
+from django.views.defaults import page_not_found
+
+from rest_framework.status import HTTP_404_NOT_FOUND, HTTP_500_INTERNAL_SERVER_ERROR
+
+
+def handler404(request, exception, **kwargs):
+    if "api" in request.build_absolute_uri():
+        return JsonResponse(
+            {
+                "type": "https://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#/10.4.5 404 Not Found",
+                "title": "Opgevraagde resource bestaat niet.",
+                "status": 404,
+                "detail": "The server has not found anything matching the Request-URI.",
+                "instance": request.build_absolute_uri(),
+                "code": "notFound",
+            },
+            status=HTTP_404_NOT_FOUND,
+        )
+    else:
+        return page_not_found(request, exception)
+
+
+def handler500(request, *args, **kwargs):
+    return JsonResponse(
+        {
+            "type": "https://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#sec10.5.1",
+            "title": "Interne server fout.",
+            "status": 500,
+            "detail": "The server encountered an unexpected condition which prevented it from fulfilling the request.",
+            "instance": request.build_absolute_uri(),
+            "code": "serverError",
+        },
+        status=HTTP_500_INTERNAL_SERVER_ERROR,
+    )

--- a/src/openpersonen/api/views/errors.py
+++ b/src/openpersonen/api/views/errors.py
@@ -4,8 +4,8 @@ from django.views.defaults import page_not_found
 from rest_framework.status import HTTP_404_NOT_FOUND, HTTP_500_INTERNAL_SERVER_ERROR
 
 
-def handler404(request, exception, **kwargs):
-    if "api" in request.build_absolute_uri():
+def handler404(request, exception):
+    if request.path.startswith("/api"):
         return JsonResponse(
             {
                 "type": "https://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#/10.4.5 404 Not Found",
@@ -21,7 +21,7 @@ def handler404(request, exception, **kwargs):
         return page_not_found(request, exception)
 
 
-def handler500(request, *args, **kwargs):
+def handler500(request):
     return JsonResponse(
         {
             "type": "https://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#sec10.5.1",

--- a/src/openpersonen/api/views/errors.py
+++ b/src/openpersonen/api/views/errors.py
@@ -3,18 +3,13 @@ from django.views.defaults import page_not_found
 
 from rest_framework.status import HTTP_404_NOT_FOUND, HTTP_500_INTERNAL_SERVER_ERROR
 
+from openpersonen.api.views.generic_responses import get_404_response
+
 
 def handler404(request, exception):
     if request.path.startswith("/api"):
         return JsonResponse(
-            {
-                "type": "https://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#/10.4.5 404 Not Found",
-                "title": "Opgevraagde resource bestaat niet.",
-                "status": 404,
-                "detail": "The server has not found anything matching the Request-URI.",
-                "instance": request.build_absolute_uri(),
-                "code": "notFound",
-            },
+            get_404_response(request.build_absolute_uri()),
             status=HTTP_404_NOT_FOUND,
         )
     else:

--- a/src/openpersonen/urls.py
+++ b/src/openpersonen/urls.py
@@ -10,6 +10,11 @@ admin.site.site_header = "openpersonen admin"
 admin.site.site_title = "openpersonen admin"
 admin.site.index_title = "Welcome to the openpersonen admin"
 
+
+handler500 = "openpersonen.api.views.errors.handler500"
+handler404 = "openpersonen.api.views.errors.handler404"
+
+
 urlpatterns = [
     path(
         "admin/password_reset/",


### PR DESCRIPTION
Fixes #80 and #81 

Django 2.2 doesn't seem to allow 500 responses in the test client https://code.djangoproject.com/ticket/18707 so that's why there are no unit tests for this but I also tested through Postman to verify it works as expected.


I forced a 500 to be raised in the code, normally this would return a 200
<img width="1904" alt="Screenshot 2020-10-27 at 15 00 50" src="https://user-images.githubusercontent.com/60747362/97313038-7a266700-1866-11eb-8cec-a29487b5eea7.png">

Custom 404 for endpoints under the 'api' endpoint
<img width="1904" alt="Screenshot 2020-10-27 at 14 53 30" src="https://user-images.githubusercontent.com/60747362/97313053-7db9ee00-1866-11eb-83fc-3f373bbdccd4.png">

Default 404 for endpoints not under the 'api' endpoint
<img width="1904" alt="Screenshot 2020-10-27 at 14 53 22" src="https://user-images.githubusercontent.com/60747362/97313057-7eeb1b00-1866-11eb-956a-5cfe1b83cc73.png">
