### PR TITLE
Adhere to v1 oas release

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -57,7 +57,7 @@ jobs:
       before_script: skip
       script:
         - generate_schema
-        - wget https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-BRP-bevragen/8afe4f2b3f89059b03d484b99647f0ec26eb55b6/specificatie/genereervariant/openapi.yaml
+        - wget https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-BRP-bevragen/v1.0.0/specificatie/openapi.yaml
         - openapi-diff openapi.yaml src/openapi.yaml
 
     - stage: "Docker image"

--- a/src/openpersonen/api/tests/views/test_nationaliteit_historie.py
+++ b/src/openpersonen/api/tests/views/test_nationaliteit_historie.py
@@ -1,53 +1,53 @@
-from django.template import loader
-from django.urls import reverse
-from django.utils.module_loading import import_string
-
-import requests_mock
-from mock import patch
-from rest_framework.test import APITestCase
-
-from openpersonen.api.tests.factory_models import TokenFactory
-from openpersonen.api.tests.test_data import NATIONALITEIT_HISTORIE_DATA
-from openpersonen.contrib.stufbg.models import StufBGClient
-
-
-@patch(
-    "openpersonen.api.data_classes.nationaliteit_historie.backend",
-    import_string("openpersonen.contrib.stufbg.backend.default"),
-)
-class TestNationaliteitHistorie(APITestCase):
-    def setUp(self):
-        super().setUp()
-        self.url = StufBGClient.get_solo().url
-        self.token = TokenFactory.create()
-
-    def test_nationaliteit_historie_without_token(self):
-        response = self.client.get(
-            reverse(
-                "nationaliteithistorie-list",
-                kwargs={"ingeschrevenpersonen_burgerservicenummer": 123456789},
-            )
-        )
-        self.assertEqual(response.status_code, 401)
-
-    @requests_mock.Mocker()
-    def test_nationaliteit_historie(self, post_mock):
-        post_mock.post(
-            self.url,
-            content=bytes(
-                loader.render_to_string("response/ResponseNationaliteitHistorie.xml"),
-                encoding="utf-8",
-            ),
-        )
-
-        response = self.client.get(
-            reverse(
-                "nationaliteithistorie-list",
-                kwargs={"ingeschrevenpersonen_burgerservicenummer": 123456789},
-            ),
-            HTTP_AUTHORIZATION=f"Token {self.token.key}",
-        )
-
-        self.assertEqual(response.status_code, 200)
-        self.assertTrue(post_mock.called)
-        self.assertEqual(response.json(), NATIONALITEIT_HISTORIE_DATA)
+# from django.template import loader
+# from django.urls import reverse
+# from django.utils.module_loading import import_string
+#
+# import requests_mock
+# from mock import patch
+# from rest_framework.test import APITestCase
+#
+# from openpersonen.api.tests.factory_models import TokenFactory
+# from openpersonen.api.tests.test_data import NATIONALITEIT_HISTORIE_DATA
+# from openpersonen.contrib.stufbg.models import StufBGClient
+#
+#
+# @patch(
+#     "openpersonen.api.data_classes.nationaliteit_historie.backend",
+#     import_string("openpersonen.contrib.stufbg.backend.default"),
+# )
+# class TestNationaliteitHistorie(APITestCase):
+#     def setUp(self):
+#         super().setUp()
+#         self.url = StufBGClient.get_solo().url
+#         self.token = TokenFactory.create()
+#
+#     def test_nationaliteit_historie_without_token(self):
+#         response = self.client.get(
+#             reverse(
+#                 "nationaliteithistorie-list",
+#                 kwargs={"ingeschrevenpersonen_burgerservicenummer": 123456789},
+#             )
+#         )
+#         self.assertEqual(response.status_code, 401)
+#
+#     @requests_mock.Mocker()
+#     def test_nationaliteit_historie(self, post_mock):
+#         post_mock.post(
+#             self.url,
+#             content=bytes(
+#                 loader.render_to_string("response/ResponseNationaliteitHistorie.xml"),
+#                 encoding="utf-8",
+#             ),
+#         )
+#
+#         response = self.client.get(
+#             reverse(
+#                 "nationaliteithistorie-list",
+#                 kwargs={"ingeschrevenpersonen_burgerservicenummer": 123456789},
+#             ),
+#             HTTP_AUTHORIZATION=f"Token {self.token.key}",
+#         )
+#
+#         self.assertEqual(response.status_code, 200)
+#         self.assertTrue(post_mock.called)
+#         self.assertEqual(response.json(), NATIONALITEIT_HISTORIE_DATA)

--- a/src/openpersonen/api/tests/views/test_nationaliteit_historie.py
+++ b/src/openpersonen/api/tests/views/test_nationaliteit_historie.py
@@ -1,53 +1,56 @@
-# from django.template import loader
-# from django.urls import reverse
-# from django.utils.module_loading import import_string
-#
-# import requests_mock
-# from mock import patch
-# from rest_framework.test import APITestCase
-#
-# from openpersonen.api.tests.factory_models import TokenFactory
-# from openpersonen.api.tests.test_data import NATIONALITEIT_HISTORIE_DATA
-# from openpersonen.contrib.stufbg.models import StufBGClient
-#
-#
-# @patch(
-#     "openpersonen.api.data_classes.nationaliteit_historie.backend",
-#     import_string("openpersonen.contrib.stufbg.backend.default"),
-# )
-# class TestNationaliteitHistorie(APITestCase):
-#     def setUp(self):
-#         super().setUp()
-#         self.url = StufBGClient.get_solo().url
-#         self.token = TokenFactory.create()
-#
-#     def test_nationaliteit_historie_without_token(self):
-#         response = self.client.get(
-#             reverse(
-#                 "nationaliteithistorie-list",
-#                 kwargs={"ingeschrevenpersonen_burgerservicenummer": 123456789},
-#             )
-#         )
-#         self.assertEqual(response.status_code, 401)
-#
-#     @requests_mock.Mocker()
-#     def test_nationaliteit_historie(self, post_mock):
-#         post_mock.post(
-#             self.url,
-#             content=bytes(
-#                 loader.render_to_string("response/ResponseNationaliteitHistorie.xml"),
-#                 encoding="utf-8",
-#             ),
-#         )
-#
-#         response = self.client.get(
-#             reverse(
-#                 "nationaliteithistorie-list",
-#                 kwargs={"ingeschrevenpersonen_burgerservicenummer": 123456789},
-#             ),
-#             HTTP_AUTHORIZATION=f"Token {self.token.key}",
-#         )
-#
-#         self.assertEqual(response.status_code, 200)
-#         self.assertTrue(post_mock.called)
-#         self.assertEqual(response.json(), NATIONALITEIT_HISTORIE_DATA)
+from unittest import skip
+
+from django.template import loader
+from django.urls import reverse
+from django.utils.module_loading import import_string
+
+import requests_mock
+from mock import patch
+from rest_framework.test import APITestCase
+
+from openpersonen.api.tests.factory_models import TokenFactory
+from openpersonen.api.tests.test_data import NATIONALITEIT_HISTORIE_DATA
+from openpersonen.contrib.stufbg.models import StufBGClient
+
+
+@patch(
+    "openpersonen.api.data_classes.nationaliteit_historie.backend",
+    import_string("openpersonen.contrib.stufbg.backend.default"),
+)
+@skip(reason="Endpoints are commented out")
+class TestNationaliteitHistorie(APITestCase):
+    def setUp(self):
+        super().setUp()
+        self.url = StufBGClient.get_solo().url
+        self.token = TokenFactory.create()
+
+    def test_nationaliteit_historie_without_token(self):
+        response = self.client.get(
+            reverse(
+                "nationaliteithistorie-list",
+                kwargs={"ingeschrevenpersonen_burgerservicenummer": 123456789},
+            )
+        )
+        self.assertEqual(response.status_code, 401)
+
+    @requests_mock.Mocker()
+    def test_nationaliteit_historie(self, post_mock):
+        post_mock.post(
+            self.url,
+            content=bytes(
+                loader.render_to_string("response/ResponseNationaliteitHistorie.xml"),
+                encoding="utf-8",
+            ),
+        )
+
+        response = self.client.get(
+            reverse(
+                "nationaliteithistorie-list",
+                kwargs={"ingeschrevenpersonen_burgerservicenummer": 123456789},
+            ),
+            HTTP_AUTHORIZATION=f"Token {self.token.key}",
+        )
+
+        self.assertEqual(response.status_code, 200)
+        self.assertTrue(post_mock.called)
+        self.assertEqual(response.json(), NATIONALITEIT_HISTORIE_DATA)

--- a/src/openpersonen/api/tests/views/test_partner_historie.py
+++ b/src/openpersonen/api/tests/views/test_partner_historie.py
@@ -1,53 +1,53 @@
-from django.template import loader
-from django.urls import reverse
-from django.utils.module_loading import import_string
-
-import requests_mock
-from mock import patch
-from rest_framework.test import APITestCase
-
-from openpersonen.api.tests.factory_models import TokenFactory
-from openpersonen.api.tests.test_data import PARTNER_HISTORIE_DATA
-from openpersonen.contrib.stufbg.models import StufBGClient
-
-
-@patch(
-    "openpersonen.api.data_classes.partner_historie.backend",
-    import_string("openpersonen.contrib.stufbg.backend.default"),
-)
-class TestPartnerHistorie(APITestCase):
-    def setUp(self):
-        super().setUp()
-        self.url = StufBGClient.get_solo().url
-        self.token = TokenFactory.create()
-
-    def test_partner_historie_without_token(self):
-        response = self.client.get(
-            reverse(
-                "partnerhistorie-list",
-                kwargs={"ingeschrevenpersonen_burgerservicenummer": 123456789},
-            )
-        )
-        self.assertEqual(response.status_code, 401)
-
-    @requests_mock.Mocker()
-    def test_partner_historie(self, post_mock):
-        post_mock.post(
-            self.url,
-            content=bytes(
-                loader.render_to_string("response/ResponsePartnerHistorie.xml"),
-                encoding="utf-8",
-            ),
-        )
-
-        response = self.client.get(
-            reverse(
-                "partnerhistorie-list",
-                kwargs={"ingeschrevenpersonen_burgerservicenummer": 123456789},
-            ),
-            HTTP_AUTHORIZATION=f"Token {self.token.key}",
-        )
-
-        self.assertEqual(response.status_code, 200)
-        self.assertTrue(post_mock.called)
-        self.assertEqual(response.json(), PARTNER_HISTORIE_DATA)
+# from django.template import loader
+# from django.urls import reverse
+# from django.utils.module_loading import import_string
+#
+# import requests_mock
+# from mock import patch
+# from rest_framework.test import APITestCase
+#
+# from openpersonen.api.tests.factory_models import TokenFactory
+# from openpersonen.api.tests.test_data import PARTNER_HISTORIE_DATA
+# from openpersonen.contrib.stufbg.models import StufBGClient
+#
+#
+# @patch(
+#     "openpersonen.api.data_classes.partner_historie.backend",
+#     import_string("openpersonen.contrib.stufbg.backend.default"),
+# )
+# class TestPartnerHistorie(APITestCase):
+#     def setUp(self):
+#         super().setUp()
+#         self.url = StufBGClient.get_solo().url
+#         self.token = TokenFactory.create()
+#
+#     def test_partner_historie_without_token(self):
+#         response = self.client.get(
+#             reverse(
+#                 "partnerhistorie-list",
+#                 kwargs={"ingeschrevenpersonen_burgerservicenummer": 123456789},
+#             )
+#         )
+#         self.assertEqual(response.status_code, 401)
+#
+#     @requests_mock.Mocker()
+#     def test_partner_historie(self, post_mock):
+#         post_mock.post(
+#             self.url,
+#             content=bytes(
+#                 loader.render_to_string("response/ResponsePartnerHistorie.xml"),
+#                 encoding="utf-8",
+#             ),
+#         )
+#
+#         response = self.client.get(
+#             reverse(
+#                 "partnerhistorie-list",
+#                 kwargs={"ingeschrevenpersonen_burgerservicenummer": 123456789},
+#             ),
+#             HTTP_AUTHORIZATION=f"Token {self.token.key}",
+#         )
+#
+#         self.assertEqual(response.status_code, 200)
+#         self.assertTrue(post_mock.called)
+#         self.assertEqual(response.json(), PARTNER_HISTORIE_DATA)

--- a/src/openpersonen/api/tests/views/test_partner_historie.py
+++ b/src/openpersonen/api/tests/views/test_partner_historie.py
@@ -1,53 +1,56 @@
-# from django.template import loader
-# from django.urls import reverse
-# from django.utils.module_loading import import_string
-#
-# import requests_mock
-# from mock import patch
-# from rest_framework.test import APITestCase
-#
-# from openpersonen.api.tests.factory_models import TokenFactory
-# from openpersonen.api.tests.test_data import PARTNER_HISTORIE_DATA
-# from openpersonen.contrib.stufbg.models import StufBGClient
-#
-#
-# @patch(
-#     "openpersonen.api.data_classes.partner_historie.backend",
-#     import_string("openpersonen.contrib.stufbg.backend.default"),
-# )
-# class TestPartnerHistorie(APITestCase):
-#     def setUp(self):
-#         super().setUp()
-#         self.url = StufBGClient.get_solo().url
-#         self.token = TokenFactory.create()
-#
-#     def test_partner_historie_without_token(self):
-#         response = self.client.get(
-#             reverse(
-#                 "partnerhistorie-list",
-#                 kwargs={"ingeschrevenpersonen_burgerservicenummer": 123456789},
-#             )
-#         )
-#         self.assertEqual(response.status_code, 401)
-#
-#     @requests_mock.Mocker()
-#     def test_partner_historie(self, post_mock):
-#         post_mock.post(
-#             self.url,
-#             content=bytes(
-#                 loader.render_to_string("response/ResponsePartnerHistorie.xml"),
-#                 encoding="utf-8",
-#             ),
-#         )
-#
-#         response = self.client.get(
-#             reverse(
-#                 "partnerhistorie-list",
-#                 kwargs={"ingeschrevenpersonen_burgerservicenummer": 123456789},
-#             ),
-#             HTTP_AUTHORIZATION=f"Token {self.token.key}",
-#         )
-#
-#         self.assertEqual(response.status_code, 200)
-#         self.assertTrue(post_mock.called)
-#         self.assertEqual(response.json(), PARTNER_HISTORIE_DATA)
+from unittest import skip
+
+from django.template import loader
+from django.urls import reverse
+from django.utils.module_loading import import_string
+
+import requests_mock
+from mock import patch
+from rest_framework.test import APITestCase
+
+from openpersonen.api.tests.factory_models import TokenFactory
+from openpersonen.api.tests.test_data import PARTNER_HISTORIE_DATA
+from openpersonen.contrib.stufbg.models import StufBGClient
+
+
+@patch(
+    "openpersonen.api.data_classes.partner_historie.backend",
+    import_string("openpersonen.contrib.stufbg.backend.default"),
+)
+@skip(reason="Endpoints are commented out")
+class TestPartnerHistorie(APITestCase):
+    def setUp(self):
+        super().setUp()
+        self.url = StufBGClient.get_solo().url
+        self.token = TokenFactory.create()
+
+    def test_partner_historie_without_token(self):
+        response = self.client.get(
+            reverse(
+                "partnerhistorie-list",
+                kwargs={"ingeschrevenpersonen_burgerservicenummer": 123456789},
+            )
+        )
+        self.assertEqual(response.status_code, 401)
+
+    @requests_mock.Mocker()
+    def test_partner_historie(self, post_mock):
+        post_mock.post(
+            self.url,
+            content=bytes(
+                loader.render_to_string("response/ResponsePartnerHistorie.xml"),
+                encoding="utf-8",
+            ),
+        )
+
+        response = self.client.get(
+            reverse(
+                "partnerhistorie-list",
+                kwargs={"ingeschrevenpersonen_burgerservicenummer": 123456789},
+            ),
+            HTTP_AUTHORIZATION=f"Token {self.token.key}",
+        )
+
+        self.assertEqual(response.status_code, 200)
+        self.assertTrue(post_mock.called)
+        self.assertEqual(response.json(), PARTNER_HISTORIE_DATA)

--- a/src/openpersonen/api/tests/views/test_verblijf_plaats_historie.py
+++ b/src/openpersonen/api/tests/views/test_verblijf_plaats_historie.py
@@ -1,53 +1,56 @@
-# from django.template import loader
-# from django.urls import reverse
-# from django.utils.module_loading import import_string
-#
-# import requests_mock
-# from mock import patch
-# from rest_framework.test import APITestCase
-#
-# from openpersonen.api.tests.factory_models import TokenFactory
-# from openpersonen.api.tests.test_data import VERBLIJF_PLAATS_HISTORIE_DATA
-# from openpersonen.contrib.stufbg.models import StufBGClient
-#
-#
-# @patch(
-#     "openpersonen.api.data_classes.verblijf_plaats_historie.backend",
-#     import_string("openpersonen.contrib.stufbg.backend.default"),
-# )
-# class TestVerblijfPlaatsHistorie(APITestCase):
-#     def setUp(self):
-#         super().setUp()
-#         self.url = StufBGClient.get_solo().url
-#         self.token = TokenFactory.create()
-#
-#     def test_verblijf_plaats_historie_without_token(self):
-#         response = self.client.get(
-#             reverse(
-#                 "verblijfplaatshistorie-list",
-#                 kwargs={"ingeschrevenpersonen_burgerservicenummer": 123456789},
-#             )
-#         )
-#         self.assertEqual(response.status_code, 401)
-#
-#     @requests_mock.Mocker()
-#     def test_verblijf_plaats_historie(self, post_mock):
-#         post_mock.post(
-#             self.url,
-#             content=bytes(
-#                 loader.render_to_string("response/ResponseVerblijfPlaatsHistorie.xml"),
-#                 encoding="utf-8",
-#             ),
-#         )
-#
-#         response = self.client.get(
-#             reverse(
-#                 "verblijfplaatshistorie-list",
-#                 kwargs={"ingeschrevenpersonen_burgerservicenummer": 123456789},
-#             ),
-#             HTTP_AUTHORIZATION=f"Token {self.token.key}",
-#         )
-#
-#         self.assertEqual(response.status_code, 200)
-#         self.assertTrue(post_mock.called)
-#         self.assertEqual(response.json(), VERBLIJF_PLAATS_HISTORIE_DATA)
+from unittest import skip
+
+from django.template import loader
+from django.urls import reverse
+from django.utils.module_loading import import_string
+
+import requests_mock
+from mock import patch
+from rest_framework.test import APITestCase
+
+from openpersonen.api.tests.factory_models import TokenFactory
+from openpersonen.api.tests.test_data import VERBLIJF_PLAATS_HISTORIE_DATA
+from openpersonen.contrib.stufbg.models import StufBGClient
+
+
+@patch(
+    "openpersonen.api.data_classes.verblijf_plaats_historie.backend",
+    import_string("openpersonen.contrib.stufbg.backend.default"),
+)
+@skip(reason="Endpoints are commented out")
+class TestVerblijfPlaatsHistorie(APITestCase):
+    def setUp(self):
+        super().setUp()
+        self.url = StufBGClient.get_solo().url
+        self.token = TokenFactory.create()
+
+    def test_verblijf_plaats_historie_without_token(self):
+        response = self.client.get(
+            reverse(
+                "verblijfplaatshistorie-list",
+                kwargs={"ingeschrevenpersonen_burgerservicenummer": 123456789},
+            )
+        )
+        self.assertEqual(response.status_code, 401)
+
+    @requests_mock.Mocker()
+    def test_verblijf_plaats_historie(self, post_mock):
+        post_mock.post(
+            self.url,
+            content=bytes(
+                loader.render_to_string("response/ResponseVerblijfPlaatsHistorie.xml"),
+                encoding="utf-8",
+            ),
+        )
+
+        response = self.client.get(
+            reverse(
+                "verblijfplaatshistorie-list",
+                kwargs={"ingeschrevenpersonen_burgerservicenummer": 123456789},
+            ),
+            HTTP_AUTHORIZATION=f"Token {self.token.key}",
+        )
+
+        self.assertEqual(response.status_code, 200)
+        self.assertTrue(post_mock.called)
+        self.assertEqual(response.json(), VERBLIJF_PLAATS_HISTORIE_DATA)

--- a/src/openpersonen/api/tests/views/test_verblijf_plaats_historie.py
+++ b/src/openpersonen/api/tests/views/test_verblijf_plaats_historie.py
@@ -1,53 +1,53 @@
-from django.template import loader
-from django.urls import reverse
-from django.utils.module_loading import import_string
-
-import requests_mock
-from mock import patch
-from rest_framework.test import APITestCase
-
-from openpersonen.api.tests.factory_models import TokenFactory
-from openpersonen.api.tests.test_data import VERBLIJF_PLAATS_HISTORIE_DATA
-from openpersonen.contrib.stufbg.models import StufBGClient
-
-
-@patch(
-    "openpersonen.api.data_classes.verblijf_plaats_historie.backend",
-    import_string("openpersonen.contrib.stufbg.backend.default"),
-)
-class TestVerblijfPlaatsHistorie(APITestCase):
-    def setUp(self):
-        super().setUp()
-        self.url = StufBGClient.get_solo().url
-        self.token = TokenFactory.create()
-
-    def test_verblijf_plaats_historie_without_token(self):
-        response = self.client.get(
-            reverse(
-                "verblijfplaatshistorie-list",
-                kwargs={"ingeschrevenpersonen_burgerservicenummer": 123456789},
-            )
-        )
-        self.assertEqual(response.status_code, 401)
-
-    @requests_mock.Mocker()
-    def test_verblijf_plaats_historie(self, post_mock):
-        post_mock.post(
-            self.url,
-            content=bytes(
-                loader.render_to_string("response/ResponseVerblijfPlaatsHistorie.xml"),
-                encoding="utf-8",
-            ),
-        )
-
-        response = self.client.get(
-            reverse(
-                "verblijfplaatshistorie-list",
-                kwargs={"ingeschrevenpersonen_burgerservicenummer": 123456789},
-            ),
-            HTTP_AUTHORIZATION=f"Token {self.token.key}",
-        )
-
-        self.assertEqual(response.status_code, 200)
-        self.assertTrue(post_mock.called)
-        self.assertEqual(response.json(), VERBLIJF_PLAATS_HISTORIE_DATA)
+# from django.template import loader
+# from django.urls import reverse
+# from django.utils.module_loading import import_string
+#
+# import requests_mock
+# from mock import patch
+# from rest_framework.test import APITestCase
+#
+# from openpersonen.api.tests.factory_models import TokenFactory
+# from openpersonen.api.tests.test_data import VERBLIJF_PLAATS_HISTORIE_DATA
+# from openpersonen.contrib.stufbg.models import StufBGClient
+#
+#
+# @patch(
+#     "openpersonen.api.data_classes.verblijf_plaats_historie.backend",
+#     import_string("openpersonen.contrib.stufbg.backend.default"),
+# )
+# class TestVerblijfPlaatsHistorie(APITestCase):
+#     def setUp(self):
+#         super().setUp()
+#         self.url = StufBGClient.get_solo().url
+#         self.token = TokenFactory.create()
+#
+#     def test_verblijf_plaats_historie_without_token(self):
+#         response = self.client.get(
+#             reverse(
+#                 "verblijfplaatshistorie-list",
+#                 kwargs={"ingeschrevenpersonen_burgerservicenummer": 123456789},
+#             )
+#         )
+#         self.assertEqual(response.status_code, 401)
+#
+#     @requests_mock.Mocker()
+#     def test_verblijf_plaats_historie(self, post_mock):
+#         post_mock.post(
+#             self.url,
+#             content=bytes(
+#                 loader.render_to_string("response/ResponseVerblijfPlaatsHistorie.xml"),
+#                 encoding="utf-8",
+#             ),
+#         )
+#
+#         response = self.client.get(
+#             reverse(
+#                 "verblijfplaatshistorie-list",
+#                 kwargs={"ingeschrevenpersonen_burgerservicenummer": 123456789},
+#             ),
+#             HTTP_AUTHORIZATION=f"Token {self.token.key}",
+#         )
+#
+#         self.assertEqual(response.status_code, 200)
+#         self.assertTrue(post_mock.called)
+#         self.assertEqual(response.json(), VERBLIJF_PLAATS_HISTORIE_DATA)

--- a/src/openpersonen/api/tests/views/test_verblijf_titel_historie.py
+++ b/src/openpersonen/api/tests/views/test_verblijf_titel_historie.py
@@ -1,53 +1,56 @@
-# from django.template import loader
-# from django.urls import reverse
-# from django.utils.module_loading import import_string
-#
-# import requests_mock
-# from mock import patch
-# from rest_framework.test import APITestCase
-#
-# from openpersonen.api.tests.factory_models import TokenFactory
-# from openpersonen.api.tests.test_data import VERBLIJFS_TITEL_HISTORIE
-# from openpersonen.contrib.stufbg.models import StufBGClient
-#
-#
-# @patch(
-#     "openpersonen.api.data_classes.verblijfs_titel_historie.backend",
-#     import_string("openpersonen.contrib.stufbg.backend.default"),
-# )
-# class TestVerblijfsTitelHistorie(APITestCase):
-#     def setUp(self):
-#         super().setUp()
-#         self.url = StufBGClient.get_solo().url
-#         self.token = TokenFactory.create()
-#
-#     def test_verblijfs_titel_historie_without_token(self):
-#         response = self.client.get(
-#             reverse(
-#                 "verblijfstitelhistorie-list",
-#                 kwargs={"ingeschrevenpersonen_burgerservicenummer": 123456789},
-#             )
-#         )
-#         self.assertEqual(response.status_code, 401)
-#
-#     @requests_mock.Mocker()
-#     def test_verblijfs_titel_historie(self, post_mock):
-#         post_mock.post(
-#             self.url,
-#             content=bytes(
-#                 loader.render_to_string("response/ResponseVerblijfsTitelHistorie.xml"),
-#                 encoding="utf-8",
-#             ),
-#         )
-#
-#         response = self.client.get(
-#             reverse(
-#                 "verblijfstitelhistorie-list",
-#                 kwargs={"ingeschrevenpersonen_burgerservicenummer": 123456789},
-#             ),
-#             HTTP_AUTHORIZATION=f"Token {self.token.key}",
-#         )
-#
-#         self.assertEqual(response.status_code, 200)
-#         self.assertTrue(post_mock.called)
-#         self.assertEqual(response.json(), VERBLIJFS_TITEL_HISTORIE)
+from unittest import skip
+
+from django.template import loader
+from django.urls import reverse
+from django.utils.module_loading import import_string
+
+import requests_mock
+from mock import patch
+from rest_framework.test import APITestCase
+
+from openpersonen.api.tests.factory_models import TokenFactory
+from openpersonen.api.tests.test_data import VERBLIJFS_TITEL_HISTORIE
+from openpersonen.contrib.stufbg.models import StufBGClient
+
+
+@patch(
+    "openpersonen.api.data_classes.verblijfs_titel_historie.backend",
+    import_string("openpersonen.contrib.stufbg.backend.default"),
+)
+@skip(reason="Endpoints are commented out")
+class TestVerblijfsTitelHistorie(APITestCase):
+    def setUp(self):
+        super().setUp()
+        self.url = StufBGClient.get_solo().url
+        self.token = TokenFactory.create()
+
+    def test_verblijfs_titel_historie_without_token(self):
+        response = self.client.get(
+            reverse(
+                "verblijfstitelhistorie-list",
+                kwargs={"ingeschrevenpersonen_burgerservicenummer": 123456789},
+            )
+        )
+        self.assertEqual(response.status_code, 401)
+
+    @requests_mock.Mocker()
+    def test_verblijfs_titel_historie(self, post_mock):
+        post_mock.post(
+            self.url,
+            content=bytes(
+                loader.render_to_string("response/ResponseVerblijfsTitelHistorie.xml"),
+                encoding="utf-8",
+            ),
+        )
+
+        response = self.client.get(
+            reverse(
+                "verblijfstitelhistorie-list",
+                kwargs={"ingeschrevenpersonen_burgerservicenummer": 123456789},
+            ),
+            HTTP_AUTHORIZATION=f"Token {self.token.key}",
+        )
+
+        self.assertEqual(response.status_code, 200)
+        self.assertTrue(post_mock.called)
+        self.assertEqual(response.json(), VERBLIJFS_TITEL_HISTORIE)

--- a/src/openpersonen/api/tests/views/test_verblijf_titel_historie.py
+++ b/src/openpersonen/api/tests/views/test_verblijf_titel_historie.py
@@ -1,53 +1,53 @@
-from django.template import loader
-from django.urls import reverse
-from django.utils.module_loading import import_string
-
-import requests_mock
-from mock import patch
-from rest_framework.test import APITestCase
-
-from openpersonen.api.tests.factory_models import TokenFactory
-from openpersonen.api.tests.test_data import VERBLIJFS_TITEL_HISTORIE
-from openpersonen.contrib.stufbg.models import StufBGClient
-
-
-@patch(
-    "openpersonen.api.data_classes.verblijfs_titel_historie.backend",
-    import_string("openpersonen.contrib.stufbg.backend.default"),
-)
-class TestVerblijfsTitelHistorie(APITestCase):
-    def setUp(self):
-        super().setUp()
-        self.url = StufBGClient.get_solo().url
-        self.token = TokenFactory.create()
-
-    def test_verblijfs_titel_historie_without_token(self):
-        response = self.client.get(
-            reverse(
-                "verblijfstitelhistorie-list",
-                kwargs={"ingeschrevenpersonen_burgerservicenummer": 123456789},
-            )
-        )
-        self.assertEqual(response.status_code, 401)
-
-    @requests_mock.Mocker()
-    def test_verblijfs_titel_historie(self, post_mock):
-        post_mock.post(
-            self.url,
-            content=bytes(
-                loader.render_to_string("response/ResponseVerblijfsTitelHistorie.xml"),
-                encoding="utf-8",
-            ),
-        )
-
-        response = self.client.get(
-            reverse(
-                "verblijfstitelhistorie-list",
-                kwargs={"ingeschrevenpersonen_burgerservicenummer": 123456789},
-            ),
-            HTTP_AUTHORIZATION=f"Token {self.token.key}",
-        )
-
-        self.assertEqual(response.status_code, 200)
-        self.assertTrue(post_mock.called)
-        self.assertEqual(response.json(), VERBLIJFS_TITEL_HISTORIE)
+# from django.template import loader
+# from django.urls import reverse
+# from django.utils.module_loading import import_string
+#
+# import requests_mock
+# from mock import patch
+# from rest_framework.test import APITestCase
+#
+# from openpersonen.api.tests.factory_models import TokenFactory
+# from openpersonen.api.tests.test_data import VERBLIJFS_TITEL_HISTORIE
+# from openpersonen.contrib.stufbg.models import StufBGClient
+#
+#
+# @patch(
+#     "openpersonen.api.data_classes.verblijfs_titel_historie.backend",
+#     import_string("openpersonen.contrib.stufbg.backend.default"),
+# )
+# class TestVerblijfsTitelHistorie(APITestCase):
+#     def setUp(self):
+#         super().setUp()
+#         self.url = StufBGClient.get_solo().url
+#         self.token = TokenFactory.create()
+#
+#     def test_verblijfs_titel_historie_without_token(self):
+#         response = self.client.get(
+#             reverse(
+#                 "verblijfstitelhistorie-list",
+#                 kwargs={"ingeschrevenpersonen_burgerservicenummer": 123456789},
+#             )
+#         )
+#         self.assertEqual(response.status_code, 401)
+#
+#     @requests_mock.Mocker()
+#     def test_verblijfs_titel_historie(self, post_mock):
+#         post_mock.post(
+#             self.url,
+#             content=bytes(
+#                 loader.render_to_string("response/ResponseVerblijfsTitelHistorie.xml"),
+#                 encoding="utf-8",
+#             ),
+#         )
+#
+#         response = self.client.get(
+#             reverse(
+#                 "verblijfstitelhistorie-list",
+#                 kwargs={"ingeschrevenpersonen_burgerservicenummer": 123456789},
+#             ),
+#             HTTP_AUTHORIZATION=f"Token {self.token.key}",
+#         )
+#
+#         self.assertEqual(response.status_code, 200)
+#         self.assertTrue(post_mock.called)
+#         self.assertEqual(response.json(), VERBLIJFS_TITEL_HISTORIE)

--- a/src/openpersonen/api/urls.py
+++ b/src/openpersonen/api/urls.py
@@ -12,12 +12,8 @@ from openpersonen.api.views import (
     APIRootView,
     IngeschrevenPersoonViewSet,
     KindViewSet,
-    NationaliteitHistorieViewSet,
     OuderViewSet,
-    PartnerHistorieViewSet,
     PartnerViewSet,
-    VerblijfPlaatsHistorieViewSet,
-    VerblijfsTitelHistorieViewSet,
 )
 
 router = routers.DefaultRouter()
@@ -44,26 +40,26 @@ router.register(
             PartnerViewSet,
             base_name="partners",
         ),
-        routers.nested(
-            "verblijfplaatshistorie",
-            VerblijfPlaatsHistorieViewSet,
-            base_name="verblijfplaatshistorie",
-        ),
-        routers.nested(
-            "partnerhistorie",
-            PartnerHistorieViewSet,
-            base_name="partnerhistorie",
-        ),
-        routers.nested(
-            "verblijfstitelhistorie",
-            VerblijfsTitelHistorieViewSet,
-            base_name="verblijfstitelhistorie",
-        ),
-        routers.nested(
-            "nationaliteithistorie",
-            NationaliteitHistorieViewSet,
-            base_name="nationaliteithistorie",
-        ),
+        # routers.nested(
+        #     "verblijfplaatshistorie",
+        #     VerblijfPlaatsHistorieViewSet,
+        #     base_name="verblijfplaatshistorie",
+        # ),
+        # routers.nested(
+        #     "partnerhistorie",
+        #     PartnerHistorieViewSet,
+        #     base_name="partnerhistorie",
+        # ),
+        # routers.nested(
+        #     "verblijfstitelhistorie",
+        #     VerblijfsTitelHistorieViewSet,
+        #     base_name="verblijfstitelhistorie",
+        # ),
+        # routers.nested(
+        #     "nationaliteithistorie",
+        #     NationaliteitHistorieViewSet,
+        #     base_name="nationaliteithistorie",
+        # ),
     ],
 )
 

--- a/src/openpersonen/api/urls.py
+++ b/src/openpersonen/api/urls.py
@@ -8,7 +8,7 @@ from vng_api_common import routers
 from vng_api_common.schema import SchemaView as _SchemaView
 
 from openpersonen.api.schema import info
-from openpersonen.api.views import (
+from openpersonen.api.views import (  # NationaliteitHistorieViewSet,; PartnerHistorieViewSet,; VerblijfPlaatsHistorieViewSet,; VerblijfsTitelHistorieViewSet,
     APIRootView,
     IngeschrevenPersoonViewSet,
     KindViewSet,


### PR DESCRIPTION
Fixes #130 

This updates the project to follow the v1.0.0 Haal-Centraal-BRP release since it's now been released from VNG-Realisatie.

Since we think that VNG-Realisatie will want the historie endpoints in the future we're just commenting them out for now so we can quickly add them back in the future. 