### PR TITLE
Disable logging to prevent sporadic failure

### DIFF
--- a/src/openpersonen/api/tests/views/test_schema.py
+++ b/src/openpersonen/api/tests/views/test_schema.py
@@ -1,3 +1,4 @@
+import logging
 from django.http import HttpRequest
 from django.urls import reverse
 
@@ -15,7 +16,10 @@ class TestSchemaView(APITestCase):
             info, "", "https://testserver.nl", None, None
         )
 
+        #  Disable logging for this function call as it logs a lot of text
+        logging.disable(logging.CRITICAL)
         schema = generator.get_schema(Request(request=HttpRequest()), True)
+        logging.disable(logging.NOTSET)
 
         self.assertEqual(schema.info, info)
 

--- a/src/openpersonen/api/tests/views/test_schema.py
+++ b/src/openpersonen/api/tests/views/test_schema.py
@@ -1,4 +1,5 @@
 import logging
+
 from django.http import HttpRequest
 from django.urls import reverse
 


### PR DESCRIPTION
Fixes #104 

I'm fairly certain that the reason the travis unit test sporadically fails is because the function `generator.get_schema` logs so much text that it blocks the io stream of travis which causes a failure.

The simplest solution seems to be to disable the logging for this function call and return to normally logging afterwards so the logging can continue as normal.