### PR TITLE
Get input from user

### DIFF
--- a/docs/installation/authorizations.rst
+++ b/docs/installation/authorizations.rst
@@ -6,8 +6,8 @@ Authorizations
 Open Personen uses API-tokens as authorizations mechanism. You can connect an
 API-token to a user for identification.
 
-Any backend change requires a change in the 
-:ref:`environment <installation_environment_config>` that are present when 
+Any backend change requires a change in the
+:ref:`environment <installation_environment_config>` that are present when
 the application is launched. Add this setting to enable authorizations:
 
 .. code:: bash
@@ -23,17 +23,17 @@ command line.
 1. Point your webbrowser to the admin interface, for example:
    ``http://localhost:8000/admin/``
 
-2. Login with the username and password of a superuser (see 
+2. Login with the username and password of a superuser (see
    :ref:`installation_quickstart`).
 
 3. Navigate to *API Autorisaties* > *Tokens*
 
 4. Click on *Token toevoegen*
 
-5. Select a *Gebruiker* to link the API token to an existing user. Click 
+5. Select a *Gebruiker* to link the API token to an existing user. Click
    on *Opslaan en opnieuw bewerken*.
 
-6. The *Key* field should now have a value like 
+6. The *Key* field should now have a value like
    ``e5640c8bde0b9b1a168595d798df721ef12bbbef``
 
 7. You can now make API calls using this API-token. For example:
@@ -48,20 +48,20 @@ command line.
 8. You can also create API-tokens from the command line:
 
    .. tabs::
-   
-      .. tab:: Development
-   
-         .. code:: shell
-   
-            $ python src/manage.py generate_token demo
-            Generated token: e5640c8bde0b9b1a168595d798df721ef12bbbef
-   
-      .. tab:: Docker
-   
-         .. code:: shell
-   
-            $ docker-compose exec web src/manage.py generate_token demo
-            Generated token: e5640c8bde0b9b1a168595d798df721ef12bbbef
 
-   This causes a user ``demo`` to be created with the generated token. By 
+      .. tab:: Development
+
+         .. code:: shell
+
+            $ python src/manage.py generate_token demo
+            API token: e5640c8bde0b9b1a168595d798df721ef12bbbef
+
+      .. tab:: Docker
+
+         .. code:: shell
+
+            $ docker-compose exec web src/manage.py generate_token demo
+            API token: e5640c8bde0b9b1a168595d798df721ef12bbbef
+
+   This causes a user ``demo`` to be created with the generated token. By
    default, this user has no permission to access the admin interface.

--- a/src/openpersonen/token/management/commands/generate_token.py
+++ b/src/openpersonen/token/management/commands/generate_token.py
@@ -7,12 +7,28 @@ User = get_user_model()
 
 
 class Command(BaseCommand):
-    help = "Create an API Token"
+    help = "Create or get an API Token"
 
     def add_arguments(self, parser):
+        parser.add_argument(
+            '--noinput', '--no-input', action='store_false', dest='interactive',
+            help="Do NOT prompt the user for input of any kind.",
+        )
+
         parser.add_argument("username", type=str)
 
     def handle(self, *args, **options):
-        user, _ = User.objects.get_or_create(username=options["username"])
-        Token.objects.filter(user=user).delete()
-        self.stdout.write(f"Generated token: {Token.objects.create(user=user).key}")
+        interactive = options['interactive']
+        username = options["username"]
+        user, _ = User.objects.get_or_create(username=username)
+
+        user_has_token = Token.objects.filter(user=user).exists()
+
+        if user_has_token and interactive and \
+            input(f'Replace existing token for {username}? [yes/no] ') != 'yes':
+            token = Token.objects.get(user=user)
+        else:
+            Token.objects.filter(user=user).delete()
+            token = Token.objects.create(user=user)
+
+        self.stdout.write(f"API token: {token.key}")

--- a/src/openpersonen/token/management/commands/generate_token.py
+++ b/src/openpersonen/token/management/commands/generate_token.py
@@ -11,21 +11,27 @@ class Command(BaseCommand):
 
     def add_arguments(self, parser):
         parser.add_argument(
-            '--noinput', '--no-input', action='store_false', dest='interactive',
+            "--noinput",
+            "--no-input",
+            action="store_false",
+            dest="interactive",
             help="Do NOT prompt the user for input of any kind.",
         )
 
         parser.add_argument("username", type=str)
 
     def handle(self, *args, **options):
-        interactive = options['interactive']
+        interactive = options["interactive"]
         username = options["username"]
         user, _ = User.objects.get_or_create(username=username)
 
         user_has_token = Token.objects.filter(user=user).exists()
 
-        if user_has_token and interactive and \
-            input(f'Replace existing token for {username}? [yes/no] ') != 'yes':
+        if (
+            user_has_token
+            and interactive
+            and input(f"Replace existing token for {username}? [yes/no] ") != "yes"
+        ):
             token = Token.objects.get(user=user)
         else:
             Token.objects.filter(user=user).delete()


### PR DESCRIPTION
Fixes #147 

Now we ask a user for input if their user already has a token.

Example usage

```bash
# First time generating the token, not asking for feedback
(env) shea@Sheas-MacBook-Pro open-personen % python src/manage.py generate_token user2 
API token: a60fa63477e695e49a1a3d05c6a26571e027b0ec

# Replacing the current token for a user
(env) shea@Sheas-MacBook-Pro open-personen % python src/manage.py generate_token user2
Replace existing token for user2? [yes/no] yes
API token: 2f5f22beaf743940e649a176cf56e199d91c4960

# Not creating new token but returning the token already created
(env) shea@Sheas-MacBook-Pro open-personen % python src/manage.py generate_token user2
Replace existing token for user2? [yes/no] no
API token: 2f5f22beaf743940e649a176cf56e199d91c4960

# Not asking for input and just recreating the token
(env) shea@Sheas-MacBook-Pro open-personen % python src/manage.py generate_token user2 --no-input
API token: fe8a3c35c535236d59e74e03456095965b874f15
(env) shea@Sheas-MacBook-Pro open-personen % python src/manage.py generate_token user2 --noinput 
API token: 31198cf3b9c89777dff2e656ccb6d13b40a30ca7
(env) shea@Sheas-MacBook-Pro open-personen %
```