### PR TITLE
Add environment variables to docker files

### DIFF
--- a/docker-compose-quickstart.yml
+++ b/docker-compose-quickstart.yml
@@ -4,6 +4,7 @@ services:
   db:
     image: postgres:12-alpine
     environment:
+      - POSTGRES_DB=${DB_NAME:-openpersonen}
       - POSTGRES_USER=${DB_USER:-openpersonen}
       - POSTGRES_PASSWORD=${DB_PASSWORD:-openpersonen}
 
@@ -18,6 +19,7 @@ services:
     environment:
       - DJANGO_SETTINGS_MODULE=openpersonen.conf.docker
       - SECRET_KEY=${SECRET_KEY:-%9+dfjw+zd3@q)ehsx(pdwy-ueq0zt=90gb4+&qd^6ytpj@p7#}
+      - DB_NAME=${DB_NAME:-openpersonen}
       - DB_USER=${DB_USER:-openpersonen}
       - DB_PASSWORD=${DB_PASSWORD:-openpersonen}
       - OPENPERSONEN_BACKEND=${OPENPERSONEN_BACKEND:-openpersonen.contrib.demo.backend.default}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,6 +4,7 @@ services:
   db:
     image: postgres:12-alpine
     environment:
+      - POSTGRES_DB=${DB_NAME:-openpersonen}
       - POSTGRES_USER=${DB_USER:-openpersonen}
       - POSTGRES_PASSWORD=${DB_PASSWORD:-openpersonen}
 
@@ -16,6 +17,7 @@ services:
     environment:
       - DJANGO_SETTINGS_MODULE=openpersonen.conf.docker
       - SECRET_KEY=${SECRET_KEY:-%9+dfjw+zd3@q)ehsx(pdwy-ueq0zt=90gb4+&qd^6ytpj@p7#}
+      - DB_NAME=${DB_NAME:-openpersonen}
       - DB_USER=${DB_USER:-openpersonen}
       - DB_PASSWORD=${DB_PASSWORD:-openpersonen}
       - OPENPERSONEN_BACKEND=${OPENPERSONEN_BACKEND:-openpersonen.contrib.demo.backend.default}


### PR DESCRIPTION
This fixes the "Quickstart Steps" travis job.  

The reason for the failure was that in our docker conf we're specifying the database name as 'openpersonen' https://github.com/maykinmedia/open-personen/blob/master/src/openpersonen/conf/docker.py#L5 however we weren't updating the `POSTGRES_DB` in the postgres container meaning it was getting the default name of 'postgres'.  This meant that the web container was not connecting to the postgres container and so when we ran the command to import the dataset it was failing.

