### PR TITLE
Feature/oas without ui

### DIFF
--- a/src/openpersonen/api/tests/views/test_schema.py
+++ b/src/openpersonen/api/tests/views/test_schema.py
@@ -42,3 +42,23 @@ class TestSchemaView(APITestCase):
         )
         self.assertEqual(response.status_code, 200)
         self.assertIn('"openapi":"3.0.0"', str(response.content))
+
+    def test_schema_view_no_ui_json(self):
+        response = self.client.get(
+            reverse("schema-ingeschreven-persoon-no-ui", kwargs={"format": ".json"})
+        )
+        self.assertEqual(response.status_code, 200)
+        self.assertIn("application/json", response["content-type"])
+        self.assertEquals(
+            response.json()["info"]["title"], "Bevragingen ingeschreven personen"
+        )
+
+    def test_schema_view_no_ui_yaml(self):
+        response = self.client.get(
+            reverse("schema-ingeschreven-persoon-no-ui", kwargs={"format": ".yaml"})
+        )
+        self.assertEqual(response.status_code, 200)
+        self.assertIn("application/yaml", response["content-type"])
+        self.assertIn(
+            "Bevragingen ingeschreven personen", response.content.decode("utf-8")
+        )

--- a/src/openpersonen/api/urls.py
+++ b/src/openpersonen/api/urls.py
@@ -85,6 +85,11 @@ urlpatterns = [
         ),
         name="schema-ingeschreven-persoon",
     ),
+    url(
+        r"^schema/openapi(?P<format>\.json|\.yaml)$",
+        SchemaView.without_ui(),
+        name="schema-ingeschreven-persoon-no-ui",
+    ),
     # actual API
     path("", include(router.urls)),
 ]


### PR DESCRIPTION
@joeribekker @shea-maykinmedia I was trying to retrieve data from Open Personen for the Open gemeente demo website, and noticed that there was no endpoint to fetch the OAS without a UI (which is needed to create a client for Open Personen via `zgw_consumers`), so I figured I'd add this