### PR TITLE
Update quickstart

### DIFF
--- a/docker-compose-quickstart.yml
+++ b/docker-compose-quickstart.yml
@@ -8,12 +8,6 @@ services:
       - POSTGRES_USER=${DB_USER:-openpersonen}
       - POSTGRES_PASSWORD=${DB_PASSWORD:-openpersonen}
 
-  busybox:
-    image: busybox
-    command: /bin/chown -R 1000 /private-media
-    volumes:
-      - private_media:/private-media
-
   web:
     image: maykinmedia/open-personen
     environment:
@@ -24,22 +18,7 @@ services:
       - DB_PASSWORD=${DB_PASSWORD:-openpersonen}
       - OPENPERSONEN_BACKEND=${OPENPERSONEN_BACKEND:-openpersonen.contrib.demo.backend.default}
       - OPENPERSONEN_USE_AUTHENTICATION=${OPENPERSONEN_USE_AUTHENTICATION:-False}
-    volumes:
-      - private_media:/app/private-media
     ports:
       - 8000:8000
     depends_on:
       - db
-
-  nginx:
-    image: nginx
-    volumes:
-      - ./default.conf:/etc/nginx/conf.d/default.conf
-      - private_media:/private-media
-    ports:
-      - "9000:80"
-    depends_on:
-      - web
-
-volumes:
-  private_media:

--- a/docs/installation/quickstart.rst
+++ b/docs/installation/quickstart.rst
@@ -3,7 +3,14 @@
 Quickstart
 ==========
 
-The default ``docker-compose`` settings have some convenience settings to get 
+.. warning::
+    The quickstart instructions are only intended for development and testing purposes.
+    Do not use the quickstart instructions in a production setting.
+    The certificate and certificate key stored in the StUF-BG Client will be exposed
+    when making an API call to an external StUF-BG service.
+
+
+The default ``docker-compose`` settings have some convenience settings to get
 started quickly and these should never be used for anything besides testing:
 
 * A default secret is set in the ``SECRET_KEY`` environment variable
@@ -35,17 +42,17 @@ With the above remarks in mind, let's go:
 
       $ docker-compose up -d
 
-3. Import a test dataset of persons. You can use the test dataset provided by 
+3. Import a test dataset of persons. You can use the test dataset provided by
    the `RvIG`_. Just copy the ODS-file URL to the command below:
 
    .. code:: shell
 
       $ docker-compose exec web src/manage.py import_demodata --url <url>
 
-4. The API should now be available on ``http://localhost:8000/api/``. You can 
+4. The API should now be available on ``http://localhost:8000/api/``. You can
    retrieve a person via the BRP API in your webbrowser:
 
-   .. code:: 
+   .. code::
 
       http://localhost:8000/api/ingeschrevenpersonen/999990676
 
@@ -55,7 +62,7 @@ With the above remarks in mind, let's go:
 Next steps
 ----------
 
-You can read how to add persons to this test dataset using this 
+You can read how to add persons to this test dataset using this
 :ref:`backends_demo_backend`. If you want to expose real persons you can connect
 Open Personen to a :ref:`backends_stufbg_backend`.
 


### PR DESCRIPTION
Fixes #67 

This work was mostly done earlier but one thing we wanted to do was remove the busybox, nginx, and docker volumes since they aren't required for the project to run and adds complexity to the quickstart instructions.

This also adds a warning about not using the quickstart in a production environment since it's not secure enough.

<img width="1904" alt="Screenshot 2020-12-08 at 13 56 01" src="https://user-images.githubusercontent.com/60747362/101487177-11023b00-395e-11eb-8734-5d76c148a370.png">
 